### PR TITLE
Perf & UX overhaul: data caching, list virtualization, and UI improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,13 +56,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -81,21 +81,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -122,14 +122,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
-      "integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -152,14 +152,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -290,29 +290,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -438,26 +438,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1607,33 +1607,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1641,13 +1641,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1746,9 +1746,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3417,34 +3417,6 @@
         "source-map-js": "^1.2.1"
       }
     },
-    "node_modules/@vue/compiler-core/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@vue/compiler-core/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
@@ -3470,34 +3442,6 @@
         "magic-string": "^0.30.21",
         "postcss": "^8.5.15",
         "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
@@ -4143,9 +4087,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5031,9 +4975,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5318,9 +5262,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -5377,19 +5321,31 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/fraction.js": {
@@ -5572,9 +5528,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6897,13 +6854,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7255,9 +7212,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8913,9 +8870,9 @@
       }
     },
     "node_modules/unplugin-utils/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8925,9 +8882,9 @@
       }
     },
     "node_modules/unplugin/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9307,9 +9264,9 @@
       }
     },
     "node_modules/vue-router/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "vue-router": "^5.1.0"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "^10.0.1",
         "@tailwindcss/forms": "^0.5.11",
         "@types/lodash.uniqby": "^4.7.9",
         "@typescript-eslint/eslint-plugin": "^8.62.0",
@@ -30,6 +32,7 @@
         "autoprefixer": "^10.5.2",
         "eslint": "^10.6.0",
         "eslint-plugin-vue": "^10.9.2",
+        "globals": "^17.7.0",
         "postcss": "^8.5.16",
         "prettier": "3.9.1",
         "tailwindcss": "^3.4.17",
@@ -1791,6 +1794,119 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -3694,6 +3810,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -4156,6 +4279,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -4276,6 +4409,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.2.2",
@@ -5464,6 +5604,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -5634,6 +5787,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -6188,6 +6358,29 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -6981,6 +7174,19 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -7528,6 +7734,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/reusify": {
@@ -8183,6 +8399,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sucrase": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     }
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
+    "@eslint/js": "^10.0.1",
     "@tailwindcss/forms": "^0.5.11",
     "@types/lodash.uniqby": "^4.7.9",
     "@typescript-eslint/eslint-plugin": "^8.62.0",
@@ -40,6 +42,7 @@
     "autoprefixer": "^10.5.2",
     "eslint": "^10.6.0",
     "eslint-plugin-vue": "^10.9.2",
+    "globals": "^17.7.0",
     "postcss": "^8.5.16",
     "prettier": "3.9.1",
     "tailwindcss": "^3.4.17",

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,23 +24,49 @@
                         </h3>
                         <ul
                             role="list"
-                            class="flex flex-col"
+                            class="flex flex-col gap-0.5"
                         >
                             <li
                                 v-for="routeItem of group.items"
                                 :key="routeItem.name"
                             >
                                 <RouterLink
+                                    v-slot="{ isExactActive, href, navigate }"
                                     :to="{
                                         path: routeItem.path,
                                         query: route.query.itemId
                                             ? { itemId: route.query.itemId }
                                             : {}
                                     }"
-                                    class="block px-2 py-1.5 rounded-lg text-black-100 hover:bg-black-300/50 hover:text-white transition-all duration-150"
-                                    active-class="text-white bg-black-300"
+                                    custom
                                 >
-                                    {{ routeItem.name }}
+                                    <a
+                                        :href="href"
+                                        class="group relative flex items-center gap-3 px-3 py-2 rounded-lg text-sm cursor-pointer transition-colors duration-150"
+                                        :class="
+                                            isExactActive
+                                                ? 'bg-black-300 text-white'
+                                                : 'text-black-100 hover:bg-black-300/50 hover:text-white'
+                                        "
+                                        @click="navigate"
+                                    >
+                                        <span
+                                            v-if="isExactActive"
+                                            class="absolute left-0 top-1/2 h-5 w-1 -translate-y-1/2 rounded-r-full bg-[#ff5e65]"
+                                        />
+                                        <component
+                                            :is="routeItem.icon"
+                                            class="size-5 shrink-0 transition-colors"
+                                            :class="
+                                                isExactActive
+                                                    ? 'text-[#ff5e65]'
+                                                    : 'text-black-100 group-hover:text-white'
+                                            "
+                                        />
+                                        <span class="truncate">{{
+                                            routeItem.name
+                                        }}</span>
+                                    </a>
                                 </RouterLink>
                             </li>
                         </ul>

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,14 +11,18 @@
                 >
                     <AppBranding />
                 </div>
-                <nav class="flex-1 px-2 py-4 overflow-y-auto">
+                <nav class="flex-1 px-2 py-4 overflow-y-auto sidebar-scroll">
                     <div
                         v-for="(group, index) of navGroups"
                         :key="group.label"
-                        :class="{ 'mt-5': index > 0 }"
+                        :class="
+                            index > 0
+                                ? 'mt-4 pt-4 border-t border-black-300/40'
+                                : ''
+                        "
                     >
                         <h3
-                            class="px-2 mb-1.5 text-[10px] uppercase tracking-widest text-black-100/50"
+                            class="px-3 mb-2 text-[10px] font-medium uppercase tracking-widest text-black-100/70"
                         >
                             {{ group.label }}
                         </h3>

--- a/src/components/BaseItemListView.vue
+++ b/src/components/BaseItemListView.vue
@@ -32,7 +32,7 @@
 import ItemsList from "./ItemsList.vue"
 import FiltersPanel from "./FiltersPanel.vue"
 import { useItemListView } from "../composables/useItemListView"
-import { Filter } from "../types"
+import { CSItem, Filter } from "../types"
 
 type QueryFunction = ({
     search,
@@ -41,7 +41,7 @@ type QueryFunction = ({
     search: string
     filters: { [prop: string]: string[] }
 }) => Promise<{
-    items: any[]
+    items: CSItem[]
     filters?: Filter[]
 }>
 

--- a/src/components/BaseItemListView.vue
+++ b/src/components/BaseItemListView.vue
@@ -14,7 +14,6 @@
             @set-sort-by="view.setSortBy($event)"
             @set-query="view.setSearch($event)"
             @select="view.selectItem"
-            @load-more="view.loadMore()"
             @open-filters="view.openFilters()"
             @remove-filter="view.removeFilter"
         />

--- a/src/components/DebugPanel.vue
+++ b/src/components/DebugPanel.vue
@@ -29,7 +29,9 @@
                 title="Raw item data"
                 has-toggle
             >
-                <pre>{{ JSON.stringify(rawItemData, null, 2) }}</pre>
+                <div class="overflow-x-auto text-xs mt-1">
+                    <RawDataTable :value="rawItemData" />
+                </div>
             </DebugItem>
         </dl>
     </div>
@@ -38,6 +40,7 @@
 <script setup lang="ts">
 import { useDebug } from "../composables/useDebug"
 import DebugItem from "./DebugItem.vue"
+import RawDataTable from "./RawDataTable.vue"
 
 const props = defineProps({
     selected: {

--- a/src/components/FiltersPanel.vue
+++ b/src/components/FiltersPanel.vue
@@ -73,14 +73,10 @@
 import { ref } from "vue"
 import { XMarkIcon, ChevronDownIcon } from "@heroicons/vue/24/outline"
 import FiltersPanelControl from "../components/FiltersPanelControl.vue"
+import { Filter } from "../types"
 
 defineProps<{
-    filters: {
-        prop: string
-        name: string
-        type: string
-        options: { id: string; name: string }[]
-    }[]
+    filters: Filter[]
     filtersValues: { [prop: string]: string[] }
 }>()
 

--- a/src/components/FiltersPanelControl.vue
+++ b/src/components/FiltersPanelControl.vue
@@ -27,12 +27,13 @@
 <script setup lang="ts">
 import MultiSelectFilter from "../components/MultiSelectFilter.vue"
 import PriceRangeFilter from "../components/PriceRangeFilter.vue"
+import { FilterOption } from "../types"
 
 defineProps<{
     prop: string
     name: string
     type: string
-    options: { id: string; name: string }[]
+    options: FilterOption[]
     values: string[]
 }>()
 

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -2,7 +2,7 @@
     <div class="flex flex-col">
         <button
             type="button"
-            class="relative block h-[12rem] p-1 overflow-hidden border-2 border-transparent rounded-md outline-none cursor-pointer focus:border-[#ff5e65] hover:border-[#ff5e65]"
+            class="relative block h-[13.5rem] p-1 overflow-hidden border-2 border-transparent rounded-md outline-none cursor-pointer focus:border-[#ff5e65] hover:border-[#ff5e65]"
             @click="$emit('show')"
         >
             <svg

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -5,6 +5,27 @@
             class="relative block h-[12rem] p-1 overflow-hidden border-2 border-transparent rounded-md outline-none cursor-pointer focus:border-[#ff5e65] hover:border-[#ff5e65]"
             @click="$emit('show')"
         >
+            <svg
+                v-if="isLoading"
+                class="absolute inset-0 z-10 m-auto size-6 animate-spin text-white/10"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+            >
+                <circle
+                    class="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    stroke-width="4"
+                />
+                <path
+                    class="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+            </svg>
             <img
                 class="object-contain w-full pointer-events-none h-full py-4 rounded-md bg-black-300/80 bg-[url('../img/graph-paper.svg')]"
                 :class="{
@@ -15,6 +36,8 @@
                 :src="image"
                 :alt="name"
                 loading="lazy"
+                @load="isLoading = false"
+                @error="isLoading = false"
             >
 
             <div class="absolute flex flex-col items-end gap-1 top-2 right-2">
@@ -62,7 +85,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue"
+import { computed, ref } from "vue"
 import { useDebug } from "../composables/useDebug"
 import { usePriceStore } from "../stores/prices"
 
@@ -81,6 +104,8 @@ defineEmits(["show"])
 
 const { isDebugMode } = useDebug()
 const priceStore = usePriceStore()
+
+const isLoading = ref(true)
 
 const formattedPrice = computed(() => priceStore.getPrice(props.marketHashName))
 const priceLabel = computed(() => {

--- a/src/components/ItemDetailPanel.vue
+++ b/src/components/ItemDetailPanel.vue
@@ -89,14 +89,33 @@
                 />
                 <!--eslint-enable-->
 
-                <a
-                    v-if="selected.style"
-                    :href="selected.style.url"
-                    class="flex ites-center text-black-100 w-full underline"
-                    target="_blank"
+                <table
+                    v-if="specs.length"
+                    class="w-full mt-1 text-sm"
                 >
-                    Finish Style: {{ selected.style.name }}
-                </a>
+                    <tbody>
+                        <tr
+                            v-for="row of specs"
+                            :key="row.label"
+                            class="border-b border-black-300/60 last:border-0"
+                        >
+                            <td
+                                class="py-1.5 pr-3 align-top whitespace-nowrap text-black-100"
+                            >
+                                {{ row.label }}
+                            </td>
+                            <td class="py-1.5 text-right align-top break-all text-white">
+                                <a
+                                    v-if="row.link"
+                                    :href="row.link"
+                                    target="_blank"
+                                    class="underline hover:text-[#ff5e65] transition-colors"
+                                >{{ row.value }}</a>
+                                <span v-else>{{ row.value }}</span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
 
             <div class="flex flex-col gap-5">
@@ -355,6 +374,34 @@ const priceLabel = computed(() => {
     return priceStore.isMarketable(props.selected.market_hash_name)
         ? "No price available"
         : "Not marketable"
+})
+
+// Specifications table built from the raw item data.
+const specs = computed(() => {
+    const raw = props.items[props.selected.id] ?? {}
+    const rows: { label: string; value: string; link?: string | null }[] = []
+
+    if (raw.style?.name) {
+        rows.push({
+            label: "Finish Style",
+            value: raw.style.name,
+            link: raw.style.url || null
+        })
+    }
+    if (raw.paint_index != null)
+        rows.push({ label: "Paint index", value: String(raw.paint_index) })
+    if (raw.pattern?.id)
+        rows.push({ label: "Pattern ID", value: String(raw.pattern.id) })
+    if (raw.phase) rows.push({ label: "Phase", value: String(raw.phase) })
+    if (typeof raw.legacy_model === "boolean")
+        rows.push({
+            label: "Legacy model",
+            value: raw.legacy_model ? "Yes" : "No"
+        })
+    if (raw.def_index != null)
+        rows.push({ label: "Def index", value: String(raw.def_index) })
+
+    return rows
 })
 
 const showItemName = ref(false)

--- a/src/components/ItemDetailPanel.vue
+++ b/src/components/ItemDetailPanel.vue
@@ -104,7 +104,9 @@
                             >
                                 {{ row.label }}
                             </td>
-                            <td class="py-1.5 text-right align-top break-all text-white">
+                            <td
+                                class="py-1.5 text-right align-top break-all text-white"
+                            >
                                 <a
                                     v-if="row.link"
                                     :href="row.link"

--- a/src/components/ItemVideo.vue
+++ b/src/components/ItemVideo.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="flex flex-col">
-        <div
-            v-if="!shouldLoadVideo"
-            class="relative w-full aspect-video rounded-md cursor-pointer bg-gray-800"
-            @click="loadVideo"
+        <button
+            type="button"
+            class="relative w-full aspect-video rounded-md cursor-pointer bg-gray-800 group"
+            @click="$emit('play')"
         >
             <img
                 :src="thumbnail"
@@ -23,13 +23,13 @@
             <!-- Play button overlay -->
             <div
                 v-if="imageLoaded"
-                class="absolute inset-0 flex items-center justify-center bg-black bg-opacity-20 rounded-md"
+                class="absolute inset-0 flex items-center justify-center bg-black bg-opacity-20 group-hover:bg-opacity-30 rounded-md transition-all"
             >
                 <div
-                    class="w-16 h-16 bg-white bg-opacity-90 rounded-full flex items-center justify-center hover:bg-opacity-100 transition-all"
+                    class="w-20 h-20 bg-white bg-opacity-90 rounded-full flex items-center justify-center group-hover:bg-opacity-100 group-hover:scale-105 transition-all"
                 >
                     <svg
-                        class="w-8 h-8 text-black ml-1"
+                        class="w-10 h-10 text-black ml-1"
                         fill="currentColor"
                         viewBox="0 0 24 24"
                     >
@@ -37,17 +37,7 @@
                     </svg>
                 </div>
             </div>
-        </div>
-
-        <video
-            v-if="shouldLoadVideo"
-            class="object-cover w-full h-full rounded-md"
-            :src="video"
-            autoplay
-            muted
-            playsinline
-            controls
-        />
+        </button>
 
         <div>
             <p
@@ -69,12 +59,7 @@ defineProps<{
     thumbnail: string
 }>()
 
-defineEmits(["show"])
+defineEmits(["play"])
 
-const shouldLoadVideo = ref(false)
 const imageLoaded = ref(false)
-
-function loadVideo() {
-    shouldLoadVideo.value = true
-}
 </script>

--- a/src/components/ItemsList.vue
+++ b/src/components/ItemsList.vue
@@ -105,8 +105,8 @@ import ItemVideo from "./ItemVideo.vue"
 import ItemsSkeleton from "./ItemsSkeleton.vue"
 import VideoModal from "./VideoModal.vue"
 
-// Fixed card height (image 12rem + name + price) plus the inter-row gap.
-const ROW_HEIGHT = 246
+// Fixed card height (image 13.5rem + name + price) plus the inter-row gap.
+const ROW_HEIGHT = 270
 const GAP = 12
 
 const props = withDefaults(
@@ -149,7 +149,7 @@ const { width } = useElementSize(scrollEl)
 const columns = computed(() => {
     const w = width.value
     if (!w) return 1
-    const cardMin = w >= 768 ? 240 : 140
+    const cardMin = w >= 768 ? 270 : 155
     return Math.max(1, Math.floor((w + GAP) / (cardMin + GAP)))
 })
 

--- a/src/components/ItemsList.vue
+++ b/src/components/ItemsList.vue
@@ -28,8 +28,8 @@
                 v-for="item in items"
                 :key="item.id"
                 :name="item.name"
-                :video="item.video"
-                :thumbnail="item.thumbnail"
+                :video="item.video ?? ''"
+                :thumbnail="item.thumbnail ?? ''"
             />
             <ItemsSkeleton v-if="loading" />
         </div>
@@ -67,7 +67,7 @@
                         :id="item.id"
                         :key="item.id"
                         :name="item.name"
-                        :image="item.image"
+                        :image="item.image ?? ''"
                         :souvenir="item?.souvenir ?? false"
                         :stattrak="item?.stattrak ?? false"
                         :genuine="item?.genuine ?? false"
@@ -82,9 +82,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue"
+import { computed, ref, type ComponentPublicInstance } from "vue"
 import { useScroll, useElementSize, useVirtualList } from "@vueuse/core"
-import { Filter } from "../types"
+import { CSItem, Filter } from "../types"
 import SearchBar from "./SearchBar.vue"
 import ItemCard from "./ItemCard.vue"
 import ItemVideo from "./ItemVideo.vue"
@@ -96,7 +96,7 @@ const GAP = 12
 
 const props = withDefaults(
     defineProps<{
-        items: any[]
+        items: CSItem[]
         itemsCount: number
         loading: boolean
         search: string
@@ -139,10 +139,10 @@ const columns = computed(() => {
 })
 
 // Group the flat item list into rows for row-based virtualization.
-const rows = computed<any[][]>(() => {
+const rows = computed<CSItem[][]>(() => {
     const cols = columns.value
     const src = props.items
-    const out: any[][] = []
+    const out: CSItem[][] = []
     for (let i = 0; i < src.length; i += cols) {
         out.push(src.slice(i, i + cols))
     }
@@ -159,9 +159,10 @@ const {
 })
 
 // Share one element between our measurement ref and useVirtualList's ref.
-function setScrollEl(el: any) {
-    scrollEl.value = el
-    ;(containerProps.ref as unknown as { value: any }).value = el
+function setScrollEl(el: Element | ComponentPublicInstance | null) {
+    const node = (el as HTMLElement | null) ?? null
+    scrollEl.value = node
+    containerProps.ref.value = node
 }
 
 // Sticky search-bar shadow uses the active container's scroll position.

--- a/src/components/ItemsList.vue
+++ b/src/components/ItemsList.vue
@@ -183,7 +183,7 @@ function setScrollEl(el: Element | ComponentPublicInstance | null) {
 // Video playback modal (highlights / souvenir charms).
 const activeIndex = ref<number | null>(null)
 const activeVideo = computed(() =>
-    activeIndex.value === null ? null : props.items[activeIndex.value] ?? null
+    activeIndex.value === null ? null : (props.items[activeIndex.value] ?? null)
 )
 const activeVideoSteamUrl = computed(() => {
     const name = activeVideo.value?.market_hash_name

--- a/src/components/ItemsList.vue
+++ b/src/components/ItemsList.vue
@@ -17,59 +17,84 @@
             @open-filters="$emit('open-filters')"
             @remove-filter="$emit('remove-filter', $event)"
         />
+
+        <!-- Video lists: modest size, rendered in full (thumbnails lazy-load). -->
         <div
-            ref="el"
-            class="grid w-full gap-3 p-4 px-5 pb-32 mx-auto overflow-y-scroll h-[calc(100vh-69px)]"
-            :class="{
-                'grid-cols-1 lg:grid-cols-2 xl:grid-cols-3': isVideo,
-                'items-grid-small md:items-grid': !isVideo
-            }"
+            v-if="isVideo"
+            ref="videoEl"
+            class="grid w-full gap-3 p-4 px-5 pb-32 mx-auto overflow-y-scroll h-[calc(100vh-69px)] grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
         >
-            <template v-if="!isVideo">
-                <ItemCard
-                    v-for="item in items"
-                    :id="item.id"
-                    :key="item.id"
-                    :name="item.name"
-                    :image="item.image"
-                    :souvenir="item?.souvenir ?? false"
-                    :stattrak="item?.stattrak ?? false"
-                    :genuine="item?.genuine ?? false"
-                    :phase="item?.phase ?? null"
-                    :market-hash-name="item.market_hash_name"
-                    @show="$emit('select', item.id)"
-                />
-            </template>
-            <template v-else>
-                <ItemVideo
-                    v-for="item in items"
-                    :key="item.id"
-                    :name="item.name"
-                    :video="item.video"
-                    :thumbnail="item.thumbnail"
-                />
-            </template>
-            <ItemsSkeleton v-if="loading" />
-            <div
-                v-if="!loading"
-                v-element-visibility="onElementVisibility"
-                class="py-10"
+            <ItemVideo
+                v-for="item in items"
+                :key="item.id"
+                :name="item.name"
+                :video="item.video"
+                :thumbnail="item.thumbnail"
             />
+            <ItemsSkeleton v-if="loading" />
+        </div>
+
+        <!-- Item grid: virtualized by row so the DOM stays constant no matter
+             how large the list is. -->
+        <div
+            v-else
+            :ref="setScrollEl"
+            :style="containerProps.style"
+            class="w-full px-5 py-4 overflow-y-scroll h-[calc(100vh-69px)]"
+            @scroll="containerProps.onScroll"
+        >
+            <div
+                v-if="loading"
+                class="grid w-full gap-3 items-grid-small md:items-grid"
+            >
+                <ItemsSkeleton />
+            </div>
+            <div
+                v-else
+                v-bind="wrapperProps"
+            >
+                <div
+                    v-for="row in virtualRows"
+                    :key="row.index"
+                    class="grid gap-3"
+                    :style="{
+                        height: `${ROW_HEIGHT}px`,
+                        gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`
+                    }"
+                >
+                    <ItemCard
+                        v-for="item in row.data"
+                        :id="item.id"
+                        :key="item.id"
+                        :name="item.name"
+                        :image="item.image"
+                        :souvenir="item?.souvenir ?? false"
+                        :stattrak="item?.stattrak ?? false"
+                        :genuine="item?.genuine ?? false"
+                        :phase="item?.phase ?? null"
+                        :market-hash-name="item.market_hash_name"
+                        @show="$emit('select', item.id)"
+                    />
+                </div>
+            </div>
         </div>
     </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue"
-import { useScroll } from "@vueuse/core"
-import { vElementVisibility } from "@vueuse/components"
+import { computed, ref } from "vue"
+import { useScroll, useElementSize, useVirtualList } from "@vueuse/core"
 import { Filter } from "../types"
 import SearchBar from "./SearchBar.vue"
 import ItemCard from "./ItemCard.vue"
 import ItemVideo from "./ItemVideo.vue"
 import ItemsSkeleton from "./ItemsSkeleton.vue"
 
-withDefaults(
+// Fixed card height (image 12rem + name + price) plus the inter-row gap.
+const ROW_HEIGHT = 246
+const GAP = 12
+
+const props = withDefaults(
     defineProps<{
         items: any[]
         itemsCount: number
@@ -92,24 +117,56 @@ withDefaults(
     }
 )
 
-const emit = defineEmits([
+defineEmits([
     "set-query",
     "set-sort-by",
     "select",
-    "load-more",
     "open-filters",
     "remove-filter"
 ])
 
-const el = ref<HTMLElement | null>(null)
-const { y } = useScroll(el)
-const isVisible = ref(false)
+// Scroll container. Measured for column count; also fed to useVirtualList.
+const scrollEl = ref<HTMLElement | null>(null)
+const { width } = useElementSize(scrollEl)
 
-function onElementVisibility(state: boolean) {
-    isVisible.value = state
+// Column count derived from the measured content width, matching the CSS grid
+// (`minmax(240px, ...)` at md+, `minmax(140px, ...)` below).
+const columns = computed(() => {
+    const w = width.value
+    if (!w) return 1
+    const cardMin = w >= 768 ? 240 : 140
+    return Math.max(1, Math.floor((w + GAP) / (cardMin + GAP)))
+})
 
-    if (state === true) {
-        emit("load-more")
+// Group the flat item list into rows for row-based virtualization.
+const rows = computed<any[][]>(() => {
+    const cols = columns.value
+    const src = props.items
+    const out: any[][] = []
+    for (let i = 0; i < src.length; i += cols) {
+        out.push(src.slice(i, i + cols))
     }
+    return out
+})
+
+const {
+    list: virtualRows,
+    containerProps,
+    wrapperProps
+} = useVirtualList(rows, {
+    itemHeight: ROW_HEIGHT,
+    overscan: 5
+})
+
+// Share one element between our measurement ref and useVirtualList's ref.
+function setScrollEl(el: any) {
+    scrollEl.value = el
+    ;(containerProps.ref as unknown as { value: any }).value = el
 }
+
+// Sticky search-bar shadow uses the active container's scroll position.
+const videoEl = ref<HTMLElement | null>(null)
+const { y: videoY } = useScroll(videoEl)
+const { y: gridY } = useScroll(scrollEl)
+const y = computed(() => (props.isVideo ? videoY.value : gridY.value))
 </script>

--- a/src/components/ItemsList.vue
+++ b/src/components/ItemsList.vue
@@ -22,7 +22,7 @@
         <div
             v-if="isVideo"
             ref="videoEl"
-            class="grid w-full gap-3 p-4 px-5 pb-32 mx-auto overflow-y-scroll h-[calc(100vh-69px)] grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+            class="grid w-full gap-4 p-4 px-5 pb-32 mx-auto overflow-y-scroll h-[calc(100vh-69px)] grid-cols-1 md:grid-cols-2"
         >
             <ItemVideo
                 v-for="item in items"
@@ -30,6 +30,7 @@
                 :name="item.name"
                 :video="item.video ?? ''"
                 :thumbnail="item.thumbnail ?? ''"
+                @play="openVideo(item)"
             />
             <ItemsSkeleton v-if="loading" />
         </div>
@@ -78,17 +79,31 @@
                 </div>
             </div>
         </div>
+
+        <VideoModal
+            :open="!!activeVideo"
+            :video="activeVideo?.video ?? ''"
+            :name="activeVideo?.name ?? ''"
+            :steam-url="activeVideoSteamUrl"
+            :has-prev="activeIndex !== null && activeIndex > 0"
+            :has-next="activeIndex !== null && activeIndex < items.length - 1"
+            @close="closeVideo"
+            @prev="prevVideo"
+            @next="nextVideo"
+        />
     </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, type ComponentPublicInstance } from "vue"
+import { computed, ref, watch, type ComponentPublicInstance } from "vue"
+import { useRoute, useRouter } from "vue-router"
 import { useScroll, useElementSize, useVirtualList } from "@vueuse/core"
 import { CSItem, Filter } from "../types"
 import SearchBar from "./SearchBar.vue"
 import ItemCard from "./ItemCard.vue"
 import ItemVideo from "./ItemVideo.vue"
 import ItemsSkeleton from "./ItemsSkeleton.vue"
+import VideoModal from "./VideoModal.vue"
 
 // Fixed card height (image 12rem + name + price) plus the inter-row gap.
 const ROW_HEIGHT = 246
@@ -164,6 +179,62 @@ function setScrollEl(el: Element | ComponentPublicInstance | null) {
     scrollEl.value = node
     containerProps.ref.value = node
 }
+
+// Video playback modal (highlights / souvenir charms).
+const activeIndex = ref<number | null>(null)
+const activeVideo = computed(() =>
+    activeIndex.value === null ? null : props.items[activeIndex.value] ?? null
+)
+const activeVideoSteamUrl = computed(() => {
+    const name = activeVideo.value?.market_hash_name
+    return name
+        ? `https://steamcommunity.com/market/listings/730/${encodeURIComponent(name)}?l=english`
+        : ""
+})
+function openVideo(item: CSItem) {
+    activeIndex.value = props.items.findIndex((i) => i.id === item.id)
+}
+function closeVideo() {
+    activeIndex.value = null
+}
+function prevVideo() {
+    if (activeIndex.value !== null && activeIndex.value > 0) activeIndex.value--
+}
+function nextVideo() {
+    if (
+        activeIndex.value !== null &&
+        activeIndex.value < props.items.length - 1
+    )
+        activeIndex.value++
+}
+
+// Reflect the open video in the URL (?video=<id>) so it can be shared.
+const route = useRoute()
+const router = useRouter()
+
+watch(
+    () => activeVideo.value?.id ?? null,
+    (id) => {
+        const query = { ...route.query }
+        if (id) query.video = id
+        else delete query.video
+        router.replace({ query })
+    }
+)
+
+// Open the shared video once the (video) list has loaded.
+watch(
+    () => props.items,
+    (items) => {
+        if (!props.isVideo || activeIndex.value !== null) return
+        const shared = route.query.video
+        if (typeof shared === "string" && shared) {
+            const idx = items.findIndex((item) => item.id === shared)
+            if (idx >= 0) activeIndex.value = idx
+        }
+    },
+    { immediate: true }
+)
 
 // Sticky search-bar shadow uses the active container's scroll position.
 const videoEl = ref<HTMLElement | null>(null)

--- a/src/components/MatrixCell.vue
+++ b/src/components/MatrixCell.vue
@@ -11,13 +11,12 @@
                     class="group relative flex flex-col items-center"
                     @click="$emit('select-item', cellData.items[0].id)"
                 >
-                    <img
+                    <SpinnerImage
                         :src="formatImageUrl(cellData.items[0].image)"
                         :alt="cellData.items[0].name"
-                        draggable="false"
-                        class="w-24 h-24 object-contain rounded hover:opacity-80 transition-opacity select-none"
-                        @dragstart.prevent
-                    >
+                        img-class="w-24 h-24 object-contain rounded hover:opacity-80 transition-opacity select-none"
+                        spinner-class="size-6"
+                    />
                     <div
                         class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-black-500 text-white text-xs rounded opacity-0 group-hover:opacity-100 pointer-events-none whitespace-nowrap z-30 max-w-[200px] text-center"
                     >
@@ -32,13 +31,11 @@
                     class="group relative flex flex-col items-center"
                     @click="$emit('select-item', item.id)"
                 >
-                    <img
+                    <SpinnerImage
                         :src="formatImageUrl(item.image)"
                         :alt="item.name"
-                        draggable="false"
-                        class="w-16 h-16 object-contain rounded hover:opacity-80 transition-opacity select-none"
-                        @dragstart.prevent
-                    >
+                        img-class="w-16 h-16 object-contain rounded hover:opacity-80 transition-opacity select-none"
+                    />
                     <div
                         class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-black-500 text-white text-xs rounded opacity-0 group-hover:opacity-100 pointer-events-none whitespace-nowrap z-30 max-w-[200px] text-center"
                     >
@@ -80,6 +77,7 @@
 
 <script setup lang="ts">
 import type { CellData } from "../services/SpecialItemsMatrixService"
+import SpinnerImage from "./SpinnerImage.vue"
 
 defineProps<{
     cellData: CellData | null

--- a/src/components/MultiSelectFilter.vue
+++ b/src/components/MultiSelectFilter.vue
@@ -8,15 +8,15 @@
         >
         <label
             v-for="option in filteredOptions"
-            :key="option.id"
+            :key="String(option.id)"
             class="flex items-center gap-2 p-2 text-gray-300 rounded-md cursor-pointer hover:bg-black-300"
         >
             <input
                 type="checkbox"
                 class="w-4 h-4 text-[#ff5e65] border-gray-300 rounded focus:ring-[#ff5e65]"
-                :value="option.id"
-                :checked="isSelected(option.id)"
-                @change="toggleOption(option.id)"
+                :value="String(option.id)"
+                :checked="isSelected(String(option.id))"
+                @change="toggleOption(String(option.id))"
             >
             {{ option.name }}
         </label>
@@ -25,9 +25,10 @@
 
 <script setup lang="ts">
 import { ref, computed } from "vue"
+import { FilterOption } from "../types"
 
 const props = defineProps<{
-    options: { id: string; name: string }[]
+    options: FilterOption[]
     values: string[]
 }>()
 

--- a/src/components/RawDataTable.vue
+++ b/src/components/RawDataTable.vue
@@ -16,8 +16,7 @@
         v-else-if="!isObject && !isArray"
         class="whitespace-nowrap"
         :class="valueClass"
-        >{{ display }}</span
-    >
+    >{{ display }}</span>
 
     <!-- Array of objects: columnar table (one row per element) -->
     <div
@@ -139,10 +138,7 @@ const isTableArray = computed(() => {
     return (
         arr.length > 0 &&
         arr.every(
-            (el) =>
-                el !== null &&
-                typeof el === "object" &&
-                !Array.isArray(el)
+            (el) => el !== null && typeof el === "object" && !Array.isArray(el)
         )
     )
 })

--- a/src/components/RawDataTable.vue
+++ b/src/components/RawDataTable.vue
@@ -1,0 +1,141 @@
+<template>
+    <!-- Primitive: render inline -->
+    <span
+        v-if="!isObject && !isArray"
+        class="break-all"
+        :class="valueClass"
+        >{{ display }}</span
+    >
+
+    <!-- Array of objects: columnar table (one row per element) -->
+    <table
+        v-else-if="isArray && isTableArray"
+        class="w-full text-left border-collapse"
+    >
+        <thead>
+            <tr>
+                <th
+                    v-for="col in columns"
+                    :key="col"
+                    class="border border-black-200 px-2 py-1 font-semibold text-white bg-black-200/40 whitespace-nowrap"
+                >
+                    {{ col }}
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr
+                v-for="(row, index) in value"
+                :key="index"
+            >
+                <td
+                    v-for="col in columns"
+                    :key="col"
+                    class="border border-black-200 px-2 py-1 align-top"
+                >
+                    <RawDataTable :value="row[col]" />
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <!-- Array of primitives / mixed: one row per entry -->
+    <table
+        v-else-if="isArray"
+        class="w-full text-left border-collapse"
+    >
+        <tbody>
+            <tr
+                v-for="(entry, index) in value"
+                :key="index"
+            >
+                <td
+                    class="border border-black-200 px-2 py-1 font-mono text-white/60 w-8 align-top"
+                >
+                    {{ index }}
+                </td>
+                <td class="border border-black-200 px-2 py-1 align-top">
+                    <RawDataTable :value="entry" />
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <!-- Object: key / value table -->
+    <table
+        v-else
+        class="w-full text-left border-collapse"
+    >
+        <tbody>
+            <tr
+                v-for="(val, key) in value"
+                :key="key"
+            >
+                <td
+                    class="border border-black-200 px-2 py-1 font-semibold text-white align-top whitespace-nowrap"
+                >
+                    {{ key }}
+                </td>
+                <td class="border border-black-200 px-2 py-1 align-top">
+                    <RawDataTable :value="val" />
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+
+const props = defineProps<{
+    value: unknown
+}>()
+
+const isArray = computed(() => Array.isArray(props.value))
+const isObject = computed(
+    () =>
+        props.value !== null &&
+        typeof props.value === "object" &&
+        !Array.isArray(props.value)
+)
+
+// An array is "table-shaped" when every element is a plain object.
+const isTableArray = computed(() => {
+    if (!isArray.value) return false
+    const arr = props.value as unknown[]
+    return (
+        arr.length > 0 &&
+        arr.every(
+            (el) =>
+                el !== null &&
+                typeof el === "object" &&
+                !Array.isArray(el)
+        )
+    )
+})
+
+// Union of keys across all row objects, preserving first-seen order.
+const columns = computed(() => {
+    const seen: string[] = []
+    for (const row of props.value as Record<string, unknown>[]) {
+        for (const key of Object.keys(row)) {
+            if (!seen.includes(key)) seen.push(key)
+        }
+    }
+    return seen
+})
+
+const display = computed(() => {
+    if (props.value === null) return "null"
+    if (props.value === undefined) return "undefined"
+    return String(props.value)
+})
+
+const valueClass = computed(() => {
+    if (props.value === null || props.value === undefined)
+        return "text-white/30 italic"
+    if (typeof props.value === "boolean") return "text-purple-300"
+    if (typeof props.value === "number") return "text-amber-300"
+    return "text-black-100"
+})
+</script>

--- a/src/components/RawDataTable.vue
+++ b/src/components/RawDataTable.vue
@@ -1,87 +1,105 @@
 <template>
-    <!-- Primitive: render inline -->
+    <!-- URL: short truncated link -->
+    <a
+        v-if="isUrl"
+        :href="stringVal"
+        target="_blank"
+        rel="noopener"
+        :title="stringVal"
+        class="inline-block max-w-[200px] truncate align-bottom text-[#ff5e65] underline"
+    >
+        {{ shortUrl }}
+    </a>
+
+    <!-- Primitive: single line -->
     <span
-        v-if="!isObject && !isArray"
-        class="break-all"
+        v-else-if="!isObject && !isArray"
+        class="whitespace-nowrap"
         :class="valueClass"
         >{{ display }}</span
     >
 
     <!-- Array of objects: columnar table (one row per element) -->
-    <table
+    <div
         v-else-if="isArray && isTableArray"
-        class="w-full text-left border-collapse"
+        class="overflow-x-auto"
     >
-        <thead>
-            <tr>
-                <th
-                    v-for="col in columns"
-                    :key="col"
-                    class="border border-black-200 px-2 py-1 font-semibold text-white bg-black-200/40 whitespace-nowrap"
+        <table class="text-left border-collapse">
+            <thead>
+                <tr>
+                    <th
+                        v-for="col in columns"
+                        :key="col"
+                        class="border border-black-200 px-2 py-1 font-semibold text-white bg-black-200/40 whitespace-nowrap"
+                    >
+                        {{ col }}
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr
+                    v-for="(row, index) in value"
+                    :key="index"
                 >
-                    {{ col }}
-                </th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr
-                v-for="(row, index) in value"
-                :key="index"
-            >
-                <td
-                    v-for="col in columns"
-                    :key="col"
-                    class="border border-black-200 px-2 py-1 align-top"
-                >
-                    <RawDataTable :value="row[col]" />
-                </td>
-            </tr>
-        </tbody>
-    </table>
+                    <td
+                        v-for="col in columns"
+                        :key="col"
+                        class="border border-black-200 px-2 py-1 align-top"
+                    >
+                        <RawDataTable :value="row[col]" />
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
     <!-- Array of primitives / mixed: one row per entry -->
-    <table
+    <div
         v-else-if="isArray"
-        class="w-full text-left border-collapse"
+        class="overflow-x-auto"
     >
-        <tbody>
-            <tr
-                v-for="(entry, index) in value"
-                :key="index"
-            >
-                <td
-                    class="border border-black-200 px-2 py-1 font-mono text-white/60 w-8 align-top"
+        <table class="text-left border-collapse">
+            <tbody>
+                <tr
+                    v-for="(entry, index) in value"
+                    :key="index"
                 >
-                    {{ index }}
-                </td>
-                <td class="border border-black-200 px-2 py-1 align-top">
-                    <RawDataTable :value="entry" />
-                </td>
-            </tr>
-        </tbody>
-    </table>
+                    <td
+                        class="border border-black-200 px-2 py-1 font-mono text-white/60 w-8 align-top"
+                    >
+                        {{ index }}
+                    </td>
+                    <td class="border border-black-200 px-2 py-1 align-top">
+                        <RawDataTable :value="entry" />
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
     <!-- Object: key / value table -->
-    <table
+    <div
         v-else
-        class="w-full text-left border-collapse"
+        class="overflow-x-auto"
     >
-        <tbody>
-            <tr
-                v-for="(val, key) in value"
-                :key="key"
-            >
-                <td
-                    class="border border-black-200 px-2 py-1 font-semibold text-white align-top whitespace-nowrap"
+        <table class="text-left border-collapse">
+            <tbody>
+                <tr
+                    v-for="(val, key) in value"
+                    :key="key"
                 >
-                    {{ key }}
-                </td>
-                <td class="border border-black-200 px-2 py-1 align-top">
-                    <RawDataTable :value="val" />
-                </td>
-            </tr>
-        </tbody>
-    </table>
+                    <td
+                        class="border border-black-200 px-2 py-1 font-semibold text-white align-top whitespace-nowrap"
+                    >
+                        {{ key }}
+                    </td>
+                    <td class="border border-black-200 px-2 py-1 align-top">
+                        <RawDataTable :value="val" />
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 </template>
 
 <script setup lang="ts">
@@ -98,6 +116,21 @@ const isObject = computed(
         typeof props.value === "object" &&
         !Array.isArray(props.value)
 )
+
+const stringVal = computed(() =>
+    typeof props.value === "string" ? props.value : ""
+)
+const isUrl = computed(() => /^https?:\/\//i.test(stringVal.value))
+// Compact label for links: host + last path segment.
+const shortUrl = computed(() => {
+    try {
+        const u = new URL(stringVal.value)
+        const last = u.pathname.split("/").filter(Boolean).pop() ?? ""
+        return last ? `${u.hostname}/…/${last}` : u.hostname
+    } catch {
+        return stringVal.value
+    }
+})
 
 // An array is "table-shaped" when every element is a plain object.
 const isTableArray = computed(() => {

--- a/src/components/SpinnerImage.vue
+++ b/src/components/SpinnerImage.vue
@@ -1,0 +1,54 @@
+<template>
+    <span class="relative inline-flex items-center justify-center">
+        <svg
+            v-if="isLoading"
+            class="absolute inset-0 m-auto animate-spin text-white/10"
+            :class="spinnerClass"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+        >
+            <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+            />
+            <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+        </svg>
+        <img
+            :src="src"
+            :alt="alt"
+            draggable="false"
+            :class="[imgClass, { 'opacity-0': isLoading }]"
+            @load="isLoading = false"
+            @error="isLoading = false"
+            @dragstart.prevent
+        >
+    </span>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue"
+
+withDefaults(
+    defineProps<{
+        src: string
+        alt: string
+        imgClass?: string
+        spinnerClass?: string
+    }>(),
+    {
+        imgClass: "",
+        spinnerClass: "size-5"
+    }
+)
+
+const isLoading = ref(true)
+</script>

--- a/src/components/VideoModal.vue
+++ b/src/components/VideoModal.vue
@@ -1,0 +1,135 @@
+<template>
+    <Transition
+        enter-active-class="transition-opacity duration-200"
+        leave-active-class="transition-opacity duration-200"
+        enter-from-class="opacity-0"
+        leave-to-class="opacity-0"
+    >
+        <div
+            v-if="open"
+            class="fixed inset-0 z-[70] flex items-center justify-center bg-black-500/85 p-4"
+            @click.self="$emit('close')"
+        >
+            <div class="flex flex-col w-full max-w-[min(92vw,124vh)]">
+                <div class="flex items-center justify-between gap-3 mb-2">
+                    <p
+                        class="text-sm sm:text-base font-medium text-white truncate"
+                        :title="name"
+                    >
+                        {{ name }}
+                    </p>
+                    <button
+                        type="button"
+                        aria-label="Close video"
+                        class="shrink-0 p-1.5 rounded-md text-black-100 hover:text-white hover:bg-black-300 transition-colors cursor-pointer"
+                        @click="$emit('close')"
+                    >
+                        <XMarkIcon class="size-6" />
+                    </button>
+                </div>
+
+                <video
+                    v-if="video"
+                    :key="video"
+                    :src="video"
+                    class="block w-full aspect-video rounded-lg bg-black-500 shadow-2xl"
+                    autoplay
+                    controls
+                    playsinline
+                    @ended="onEnded"
+                />
+
+                <!-- Controls under the video -->
+                <div class="mt-3 flex flex-wrap items-center gap-2 sm:gap-3">
+                    <button
+                        type="button"
+                        :disabled="!hasPrev"
+                        class="flex-1 sm:flex-none flex items-center justify-center gap-1 px-3 py-2.5 sm:py-2 rounded-lg text-sm text-white bg-black-300 transition-colors hover:bg-black-200 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+                        @click="$emit('prev')"
+                    >
+                        <ChevronLeftIcon class="size-5" />
+                        Prev
+                    </button>
+                    <button
+                        type="button"
+                        :disabled="!hasNext"
+                        class="flex-1 sm:flex-none flex items-center justify-center gap-1 px-3 py-2.5 sm:py-2 rounded-lg text-sm text-white bg-black-300 transition-colors hover:bg-black-200 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+                        @click="$emit('next')"
+                    >
+                        Next
+                        <ChevronRightIcon class="size-5" />
+                    </button>
+
+                    <label
+                        class="flex items-center gap-2 px-2 py-1 text-sm text-gray-300 cursor-pointer select-none"
+                    >
+                        <input
+                            v-model="autoNext"
+                            type="checkbox"
+                            class="size-4 rounded border-black-200 bg-black-300 text-[#ff5e65] focus:ring-[#ff5e65] cursor-pointer"
+                        >
+                        Autoplay next
+                    </label>
+
+                    <a
+                        v-if="steamUrl"
+                        :href="steamUrl"
+                        target="_blank"
+                        rel="noopener"
+                        class="w-full sm:w-auto sm:ml-auto flex items-center justify-center gap-1.5 px-3 py-2.5 sm:py-2 rounded-lg text-sm text-white bg-black-300 transition-colors hover:bg-black-200 cursor-pointer"
+                    >
+                        <LinkIcon class="size-5" />
+                        Steam Community Market
+                    </a>
+                </div>
+            </div>
+        </div>
+    </Transition>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onBeforeUnmount } from "vue"
+import {
+    XMarkIcon,
+    ChevronLeftIcon,
+    ChevronRightIcon,
+    LinkIcon
+} from "@heroicons/vue/24/outline"
+
+const props = defineProps<{
+    open: boolean
+    video: string
+    name: string
+    steamUrl: string
+    hasPrev: boolean
+    hasNext: boolean
+}>()
+
+const emit = defineEmits<{
+    close: []
+    prev: []
+    next: []
+}>()
+
+const autoNext = ref(true)
+
+function onEnded() {
+    if (autoNext.value && props.hasNext) emit("next")
+}
+
+function onKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") emit("close")
+    else if (e.key === "ArrowLeft" && props.hasPrev) emit("prev")
+    else if (e.key === "ArrowRight" && props.hasNext) emit("next")
+}
+
+watch(
+    () => props.open,
+    (isOpen) => {
+        if (isOpen) window.addEventListener("keydown", onKeydown)
+        else window.removeEventListener("keydown", onKeydown)
+    }
+)
+
+onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown))
+</script>

--- a/src/composables/useItemListView.ts
+++ b/src/composables/useItemListView.ts
@@ -2,7 +2,7 @@ import { ref, computed, ComputedRef } from "vue"
 import { createListStore } from "../stores/list"
 import { useItemDetailStore } from "../stores/ItemDetail"
 import { useTitle } from "../composable/useTitle"
-import { Filter } from "../types"
+import { CSItem, Filter } from "../types"
 
 type QueryFunction = ({
     search,
@@ -11,7 +11,7 @@ type QueryFunction = ({
     search: string
     filters: { [prop: string]: string[] }
 }) => Promise<{
-    items: any[]
+    items: CSItem[]
     filters?: Filter[]
 }>
 

--- a/src/composables/useItemListView.ts
+++ b/src/composables/useItemListView.ts
@@ -97,7 +97,6 @@ export function useItemListView(options: UseItemListViewOptions) {
 
         // Methods
         setSearch: listStore.setSearch,
-        loadMore: listStore.loadMore,
         openFilters,
         closeFilters,
         selectItem,

--- a/src/services/AgentsService.ts
+++ b/src/services/AgentsService.ts
@@ -1,5 +1,26 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/agents.json`
+    )
+
+    const [rarity, team] = generateOptionsBatch(items, [
+        { type: "fromNestedSingleProperty", property: "rarity" },
+        { type: "fromNestedSingleProperty", property: "team" }
+    ])
+
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
+            { prop: "team", name: "Team", type: "multi-select", options: team }
+        ]
+    }
+}
 
 export default class AgentsService {
     async query({
@@ -9,40 +30,10 @@ export default class AgentsService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/agents.json`
-        )
-
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
-            {
-                prop: "rarity",
-                name: "Rarity",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "rarity"
-                })
-            },
-            {
-                prop: "team",
-                name: "Team",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "team"
-                })
-            }
-        ]
-
+        const built = await getOrBuild("agents", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/AgentsService.ts
+++ b/src/services/AgentsService.ts
@@ -16,8 +16,18 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
-            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
+            {
+                prop: "rarity",
+                name: "Rarity",
+                type: "multi-select",
+                options: rarity
+            },
             { prop: "team", name: "Team", type: "multi-select", options: team }
         ]
     }

--- a/src/services/AgentsService.ts
+++ b/src/services/AgentsService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/agents.json`
     )
 

--- a/src/services/BaseWeaponsService.ts
+++ b/src/services/BaseWeaponsService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/base_weapons.json`
     )
 

--- a/src/services/BaseWeaponsService.ts
+++ b/src/services/BaseWeaponsService.ts
@@ -1,5 +1,14 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/base_weapons.json`
+    )
+
+    return { items, filters: [] }
+}
 
 export default class BaseWeaponsService {
     async query({
@@ -9,13 +18,10 @@ export default class BaseWeaponsService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/base_weapons.json`
-        )
-
+        const built = await getOrBuild("base-weapons", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: []
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/CharmsService.ts
+++ b/src/services/CharmsService.ts
@@ -16,9 +16,24 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
-            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
-            { prop: "collections", name: "Collections", type: "multi-select", options: collections }
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
+            {
+                prop: "rarity",
+                name: "Rarity",
+                type: "multi-select",
+                options: rarity
+            },
+            {
+                prop: "collections",
+                name: "Collections",
+                type: "multi-select",
+                options: collections
+            }
         ]
     }
 }

--- a/src/services/CharmsService.ts
+++ b/src/services/CharmsService.ts
@@ -1,5 +1,26 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/keychains.json`
+    )
+
+    const [rarity, collections] = generateOptionsBatch(items, [
+        { type: "fromNestedSingleProperty", property: "rarity" },
+        { type: "fromNestedProperty", property: "collections" }
+    ])
+
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
+            { prop: "collections", name: "Collections", type: "multi-select", options: collections }
+        ]
+    }
+}
 
 export default class CharmsService {
     async query({
@@ -9,40 +30,10 @@ export default class CharmsService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/keychains.json`
-        )
-
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
-            {
-                prop: "rarity",
-                name: "Rarity",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "rarity"
-                })
-            },
-            {
-                prop: "collections",
-                name: "Collections",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "collections"
-                })
-            }
-        ]
-
+        const built = await getOrBuild("charms", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/CharmsService.ts
+++ b/src/services/CharmsService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/keychains.json`
     )
 

--- a/src/services/CollectiblesService.ts
+++ b/src/services/CollectiblesService.ts
@@ -1,42 +1,26 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
 
-export default class CollectiblesService {
-    async query({
-        search,
-        filters
-    }: {
-        search: string
-        filters: { [prop: string]: string[] }
-    }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/collectibles.json`
-        )
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/collectibles.json`
+    )
 
-        const filterList = [
-            {
-                prop: "rarity",
-                name: "Rarity",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "rarity"
-                })
-            },
+    const [rarity, type] = generateOptionsBatch(items, [
+        { type: "fromNestedSingleProperty", property: "rarity" },
+        { type: "fromProperty", property: "type" }
+    ])
+
+    return {
+        items,
+        filters: [
+            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
             {
                 prop: "type",
                 name: "Type",
                 type: "multi-select",
-                options: [
-                    ...generateOptions(items, {
-                        type: "fromProperty",
-                        property: "type"
-                    }),
-                    {
-                        id: "null",
-                        name: "Other"
-                    }
-                ]
+                options: [...type, { id: "null", name: "Other" }]
             },
             {
                 prop: "genuine",
@@ -48,10 +32,21 @@ export default class CollectiblesService {
                 ]
             }
         ]
+    }
+}
 
+export default class CollectiblesService {
+    async query({
+        search,
+        filters
+    }: {
+        search: string
+        filters: { [prop: string]: string[] }
+    }) {
+        const built = await getOrBuild("collectibles", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/CollectiblesService.ts
+++ b/src/services/CollectiblesService.ts
@@ -16,7 +16,12 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
+            {
+                prop: "rarity",
+                name: "Rarity",
+                type: "multi-select",
+                options: rarity
+            },
             {
                 prop: "type",
                 name: "Type",

--- a/src/services/CollectiblesService.ts
+++ b/src/services/CollectiblesService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/collectibles.json`
     )
 

--- a/src/services/CollectionsService.ts
+++ b/src/services/CollectionsService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/collections.json`
     )
 

--- a/src/services/CollectionsService.ts
+++ b/src/services/CollectionsService.ts
@@ -16,8 +16,18 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "crates", name: "Crate", type: "multi-select", options: crates },
-            { prop: "contains", name: "Contains", type: "multi-select", options: contains }
+            {
+                prop: "crates",
+                name: "Crate",
+                type: "multi-select",
+                options: crates
+            },
+            {
+                prop: "contains",
+                name: "Contains",
+                type: "multi-select",
+                options: contains
+            }
         ]
     }
 }

--- a/src/services/CollectionsService.ts
+++ b/src/services/CollectionsService.ts
@@ -1,5 +1,25 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/collections.json`
+    )
+
+    const [crates, contains] = generateOptionsBatch(items, [
+        { type: "fromNestedProperty", property: "crates" },
+        { type: "fromNestedProperty", property: "contains" }
+    ])
+
+    return {
+        items,
+        filters: [
+            { prop: "crates", name: "Crate", type: "multi-select", options: crates },
+            { prop: "contains", name: "Contains", type: "multi-select", options: contains }
+        ]
+    }
+}
 
 export default class CollectionsService {
     async query({
@@ -9,34 +29,10 @@ export default class CollectionsService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/collections.json`
-        )
-
-        const filterList = [
-            {
-                prop: "crates",
-                name: "Crate",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "crates"
-                })
-            },
-            {
-                prop: "contains",
-                name: "Contains",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "contains"
-                })
-            }
-        ]
-
+        const built = await getOrBuild("collections", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/CratesService.ts
+++ b/src/services/CratesService.ts
@@ -17,9 +17,24 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
-            { prop: "contains", name: "Contains", type: "multi-select", options: contains },
-            { prop: "contains_rare", name: "Contains special", type: "multi-select", options: containsRare },
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
+            {
+                prop: "contains",
+                name: "Contains",
+                type: "multi-select",
+                options: contains
+            },
+            {
+                prop: "contains_rare",
+                name: "Contains special",
+                type: "multi-select",
+                options: containsRare
+            },
             { prop: "type", name: "Type", type: "multi-select", options: type }
         ]
     }

--- a/src/services/CratesService.ts
+++ b/src/services/CratesService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/crates.json`
     )
 

--- a/src/services/CratesService.ts
+++ b/src/services/CratesService.ts
@@ -1,5 +1,28 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/crates.json`
+    )
+
+    const [contains, containsRare, type] = generateOptionsBatch(items, [
+        { type: "fromNestedProperty", property: "contains" },
+        { type: "fromNestedProperty", property: "contains_rare" },
+        { type: "fromProperty", property: "type" }
+    ])
+
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            { prop: "contains", name: "Contains", type: "multi-select", options: contains },
+            { prop: "contains_rare", name: "Contains special", type: "multi-select", options: containsRare },
+            { prop: "type", name: "Type", type: "multi-select", options: type }
+        ]
+    }
+}
 
 export default class CratesService {
     async query({
@@ -9,49 +32,10 @@ export default class CratesService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/crates.json`
-        )
-
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
-            {
-                prop: "contains",
-                name: "Contains",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "contains"
-                })
-            },
-            {
-                prop: "contains_rare",
-                name: "Contains special",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "contains_rare"
-                })
-            },
-            {
-                prop: "type",
-                name: "Type",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "type"
-                })
-            }
-        ]
-
+        const built = await getOrBuild("crates", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/GraffitiService.ts
+++ b/src/services/GraffitiService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/graffiti.json`
     )
 

--- a/src/services/GraffitiService.ts
+++ b/src/services/GraffitiService.ts
@@ -16,9 +16,24 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
-            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
-            { prop: "crates", name: "Crate", type: "multi-select", options: crates }
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
+            {
+                prop: "rarity",
+                name: "Rarity",
+                type: "multi-select",
+                options: rarity
+            },
+            {
+                prop: "crates",
+                name: "Crate",
+                type: "multi-select",
+                options: crates
+            }
         ]
     }
 }

--- a/src/services/GraffitiService.ts
+++ b/src/services/GraffitiService.ts
@@ -1,5 +1,26 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/graffiti.json`
+    )
+
+    const [rarity, crates] = generateOptionsBatch(items, [
+        { type: "fromNestedSingleProperty", property: "rarity" },
+        { type: "fromNestedProperty", property: "crates" }
+    ])
+
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
+            { prop: "crates", name: "Crate", type: "multi-select", options: crates }
+        ]
+    }
+}
 
 export default class GraffitiService {
     async query({
@@ -9,40 +30,10 @@ export default class GraffitiService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/graffiti.json`
-        )
-
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
-            {
-                prop: "rarity",
-                name: "Rarity",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "rarity"
-                })
-            },
-            {
-                prop: "crates",
-                name: "Crate",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "crates"
-                })
-            }
-        ]
-
+        const built = await getOrBuild("graffiti", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/HighlightsService.ts
+++ b/src/services/HighlightsService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/highlights.json`
     )
 

--- a/src/services/HighlightsService.ts
+++ b/src/services/HighlightsService.ts
@@ -21,12 +21,37 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "tournament_event", name: "Tournament", type: "multi-select", options: tournamentEvent },
-            { prop: "tournament_player", name: "Player", type: "multi-select", options: tournamentPlayer },
+            {
+                prop: "tournament_event",
+                name: "Tournament",
+                type: "multi-select",
+                options: tournamentEvent
+            },
+            {
+                prop: "tournament_player",
+                name: "Player",
+                type: "multi-select",
+                options: tournamentPlayer
+            },
             { prop: "map", name: "Map", type: "multi-select", options: map },
-            { prop: "stage", name: "Stage", type: "multi-select", options: stage },
-            { prop: "team0", name: "Team 0", type: "multi-select", options: team0 },
-            { prop: "team1", name: "Team 1", type: "multi-select", options: team1 }
+            {
+                prop: "stage",
+                name: "Stage",
+                type: "multi-select",
+                options: stage
+            },
+            {
+                prop: "team0",
+                name: "Team 0",
+                type: "multi-select",
+                options: team0
+            },
+            {
+                prop: "team1",
+                name: "Team 1",
+                type: "multi-select",
+                options: team1
+            }
         ]
     }
 }

--- a/src/services/HighlightsService.ts
+++ b/src/services/HighlightsService.ts
@@ -1,5 +1,34 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/highlights.json`
+    )
+
+    const [tournamentEvent, tournamentPlayer, map, stage, team0, team1] =
+        generateOptionsBatch(items, [
+            { type: "fromProperty", property: "tournament_event" },
+            { type: "fromProperty", property: "tournament_player" },
+            { type: "fromProperty", property: "map" },
+            { type: "fromProperty", property: "stage" },
+            { type: "fromProperty", property: "team0" },
+            { type: "fromProperty", property: "team1" }
+        ])
+
+    return {
+        items,
+        filters: [
+            { prop: "tournament_event", name: "Tournament", type: "multi-select", options: tournamentEvent },
+            { prop: "tournament_player", name: "Player", type: "multi-select", options: tournamentPlayer },
+            { prop: "map", name: "Map", type: "multi-select", options: map },
+            { prop: "stage", name: "Stage", type: "multi-select", options: stage },
+            { prop: "team0", name: "Team 0", type: "multi-select", options: team0 },
+            { prop: "team1", name: "Team 1", type: "multi-select", options: team1 }
+        ]
+    }
+}
 
 export default class HighlightsService {
     async query({
@@ -9,70 +38,10 @@ export default class HighlightsService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/highlights.json`
-        )
-
-        const filterList = [
-            {
-                prop: "tournament_event",
-                name: "Tournament",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "tournament_event"
-                })
-            },
-            {
-                prop: "tournament_player",
-                name: "Player",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "tournament_player"
-                })
-            },
-            {
-                prop: "map",
-                name: "Map",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "map"
-                })
-            },
-            {
-                prop: "stage",
-                name: "Stage",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "stage"
-                })
-            },
-            {
-                prop: "team0",
-                name: "Team 0",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "team0"
-                })
-            },
-            {
-                prop: "team1",
-                name: "Team 1",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "team1"
-                })
-            }
-        ]
-
+        const built = await getOrBuild("highlights", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/HomeService.ts
+++ b/src/services/HomeService.ts
@@ -1,13 +1,14 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, shuffleArrayWithSeed } from "../utils/index"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const rawData = await cachedGet<Record<string, any>>(
+    const rawData = await cachedGet<Record<string, CSItem>>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/all.json`
     )
 
-    const items = Object.values(rawData).map((item: any) => {
+    const items = Object.values(rawData).map((item): CSItem => {
         let imageDomain = "unknown"
         if (item.image) {
             try {
@@ -91,26 +92,26 @@ export default class HomeService {
     async getAllItems() {
         const [allRaw, skins, collectibles, baseWeapons, highlights] =
             await Promise.all([
-                cachedGet<Record<string, any>>(
+                cachedGet<Record<string, CSItem>>(
                     `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/all.json`
                 ),
-                cachedGet<any[]>(
+                cachedGet<CSItem[]>(
                     `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/skins.json`
                 ),
-                cachedGet<any[]>(
+                cachedGet<CSItem[]>(
                     `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/collectibles.json`
                 ),
-                cachedGet<any[]>(
+                cachedGet<CSItem[]>(
                     `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/base_weapons.json`
                 ),
-                cachedGet<any[]>(
+                cachedGet<CSItem[]>(
                     `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/highlights.json`
                 )
             ])
 
         // Shallow-copy each entry so the mutations below never touch the
         // shared cached all.json object (cachedGet no longer clones).
-        const items: Record<string, any> = {}
+        const items: Record<string, CSItem> = {}
         for (const [key, value] of Object.entries(allRaw)) {
             items[key] = { ...value }
         }

--- a/src/services/HomeService.ts
+++ b/src/services/HomeService.ts
@@ -1,53 +1,44 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, shuffleArrayWithSeed } from "../utils/index"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
 
-export default class HomeService {
-    async query({
-        search,
-        filters
-    }: {
-        search: string
-        filters: { [prop: string]: string[] }
-    }) {
-        const rawData = await cachedGet<Record<string, any>>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/all.json`
-        )
-        let items: {
-            name: string
-            image: string
-            image_domain?: string /* more properties */
-        }[] = Object.values(rawData)
+async function build(): Promise<BuiltCategory> {
+    const rawData = await cachedGet<Record<string, any>>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/all.json`
+    )
 
-        items = items.map((item) => {
-            let imageDomain = "unknown"
-            if (item.image) {
-                try {
-                    const url = new URL(item.image)
-                    imageDomain = url.hostname
-                } catch {
-                    // If URL parsing fails, try to extract domain from string
-                    const match = item.image.match(/https?:\/\/([^\/]+)/)
-                    if (match) {
-                        imageDomain = match[1]
-                    }
+    const items = Object.values(rawData).map((item: any) => {
+        let imageDomain = "unknown"
+        if (item.image) {
+            try {
+                const url = new URL(item.image)
+                imageDomain = url.hostname
+            } catch {
+                // If URL parsing fails, try to extract domain from string
+                const match = item.image.match(/https?:\/\/([^\/]+)/)
+                if (match) {
+                    imageDomain = match[1]
                 }
             }
-            return {
-                ...item,
-                image_domain: imageDomain
-            }
-        })
+        }
+        return {
+            ...item,
+            image_domain: imageDomain
+        }
+    })
 
-        // Get unique domains from all items
-        const uniqueDomains = Array.from(
-            new Set(
-                items
-                    .map((item) => item.image_domain)
-                    .filter((domain): domain is string => Boolean(domain))
-            )
-        ).sort()
+    // Get unique domains from all items
+    const uniqueDomains = Array.from(
+        new Set(
+            items
+                .map((item) => item.image_domain)
+                .filter((domain): domain is string => Boolean(domain))
+        )
+    ).sort()
 
-        const filterList = [
+    return {
+        items,
+        filters: [
             {
                 prop: "price_range",
                 name: "Price",
@@ -64,27 +55,41 @@ export default class HomeService {
                 }))
             }
         ]
+    }
+}
 
-        let filteredItems = items
+export default class HomeService {
+    async query({
+        search,
+        filters
+    }: {
+        search: string
+        filters: { [prop: string]: string[] }
+    }) {
+        const built = await getOrBuild("home", build)
+
+        let filteredItems
         if (Object.keys(filters).length > 0) {
-            filteredItems = filterItems(items, search, filters)
+            filteredItems = filterItems(built.items, search, filters)
         } else if (search) {
-            filteredItems = filterItems(items, search)
+            filteredItems = filterItems(built.items, search)
         } else {
+            // Copy before shuffling — shuffleArrayWithSeed mutates in place and
+            // built.items is the shared cached array.
             filteredItems = shuffleArrayWithSeed(
-                items,
+                [...built.items],
                 new Date().toISOString().slice(0, 10)
             )
         }
 
         return {
             items: filteredItems,
-            filters: filterList
+            filters: built.filters
         }
     }
 
     async getAllItems() {
-        const [items, skins, collectibles, baseWeapons, highlights] =
+        const [allRaw, skins, collectibles, baseWeapons, highlights] =
             await Promise.all([
                 cachedGet<Record<string, any>>(
                     `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/all.json`
@@ -102,6 +107,13 @@ export default class HomeService {
                     `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/highlights.json`
                 )
             ])
+
+        // Shallow-copy each entry so the mutations below never touch the
+        // shared cached all.json object (cachedGet no longer clones).
+        const items: Record<string, any> = {}
+        for (const [key, value] of Object.entries(allRaw)) {
+            items[key] = { ...value }
+        }
 
         const collectibleConfigs = [
             {

--- a/src/services/KeysService.ts
+++ b/src/services/KeysService.ts
@@ -1,34 +1,21 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
 
-export default class KeysService {
-    async query({
-        search,
-        filters
-    }: {
-        search: string
-        filters: { [prop: string]: string[] }
-    }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/keys.json`
-        )
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/keys.json`
+    )
 
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
-            {
-                prop: "crates",
-                name: "Crate",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "crates"
-                })
-            },
+    const [crates] = generateOptionsBatch(items, [
+        { type: "fromNestedProperty", property: "crates" }
+    ])
+
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            { prop: "crates", name: "Crate", type: "multi-select", options: crates },
             {
                 prop: "marketable",
                 name: "Marketable",
@@ -39,10 +26,21 @@ export default class KeysService {
                 ]
             }
         ]
+    }
+}
 
+export default class KeysService {
+    async query({
+        search,
+        filters
+    }: {
+        search: string
+        filters: { [prop: string]: string[] }
+    }) {
+        const built = await getOrBuild("keys", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/KeysService.ts
+++ b/src/services/KeysService.ts
@@ -15,8 +15,18 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
-            { prop: "crates", name: "Crate", type: "multi-select", options: crates },
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
+            {
+                prop: "crates",
+                name: "Crate",
+                type: "multi-select",
+                options: crates
+            },
             {
                 prop: "marketable",
                 name: "Marketable",

--- a/src/services/KeysService.ts
+++ b/src/services/KeysService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/keys.json`
     )
 

--- a/src/services/MusicKitsService.ts
+++ b/src/services/MusicKitsService.ts
@@ -1,25 +1,16 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
 
-export default class MusicKitsService {
-    async query({
-        search,
-        filters
-    }: {
-        search: string
-        filters: { [prop: string]: string[] }
-    }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/music_kits.json`
-        )
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/music_kits.json`
+    )
 
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
             {
                 prop: "exclusive",
                 name: "Exclusive",
@@ -30,10 +21,21 @@ export default class MusicKitsService {
                 ]
             }
         ]
+    }
+}
 
+export default class MusicKitsService {
+    async query({
+        search,
+        filters
+    }: {
+        search: string
+        filters: { [prop: string]: string[] }
+    }) {
+        const built = await getOrBuild("music-kits", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/MusicKitsService.ts
+++ b/src/services/MusicKitsService.ts
@@ -11,7 +11,12 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
             {
                 prop: "exclusive",
                 name: "Exclusive",

--- a/src/services/MusicKitsService.ts
+++ b/src/services/MusicKitsService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/music_kits.json`
     )
 

--- a/src/services/PatchesService.ts
+++ b/src/services/PatchesService.ts
@@ -15,8 +15,18 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
-            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity }
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
+            {
+                prop: "rarity",
+                name: "Rarity",
+                type: "multi-select",
+                options: rarity
+            }
         ]
     }
 }

--- a/src/services/PatchesService.ts
+++ b/src/services/PatchesService.ts
@@ -1,5 +1,24 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/patches.json`
+    )
+
+    const [rarity] = generateOptionsBatch(items, [
+        { type: "fromNestedSingleProperty", property: "rarity" }
+    ])
+
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity }
+        ]
+    }
+}
 
 export default class PatchesService {
     async query({
@@ -9,31 +28,10 @@ export default class PatchesService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/patches.json`
-        )
-
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
-            {
-                prop: "rarity",
-                name: "Rarity",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "rarity"
-                })
-            }
-        ]
-
+        const built = await getOrBuild("patches", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/PatchesService.ts
+++ b/src/services/PatchesService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/patches.json`
     )
 

--- a/src/services/SkinService.ts
+++ b/src/services/SkinService.ts
@@ -56,16 +56,61 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
-            { prop: "crates", name: "Crates", type: "multi-select", options: crates },
-            { prop: "collections", name: "Collections", type: "multi-select", options: collections },
-            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
-            { prop: "pattern", name: "Pattern", type: "multi-select", options: pattern },
-            { prop: "style", name: "Finish Style", type: "multi-select", options: style },
-            { prop: "weapon", name: "Weapon", type: "multi-select", options: weapon },
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
+            {
+                prop: "crates",
+                name: "Crates",
+                type: "multi-select",
+                options: crates
+            },
+            {
+                prop: "collections",
+                name: "Collections",
+                type: "multi-select",
+                options: collections
+            },
+            {
+                prop: "rarity",
+                name: "Rarity",
+                type: "multi-select",
+                options: rarity
+            },
+            {
+                prop: "pattern",
+                name: "Pattern",
+                type: "multi-select",
+                options: pattern
+            },
+            {
+                prop: "style",
+                name: "Finish Style",
+                type: "multi-select",
+                options: style
+            },
+            {
+                prop: "weapon",
+                name: "Weapon",
+                type: "multi-select",
+                options: weapon
+            },
             { prop: "wear", name: "Wear", type: "multi-select", options: wear },
-            { prop: "category", name: "Category", type: "multi-select", options: category },
-            { prop: "paint_index", name: "Paint index", type: "multi-select", options: paintIndex },
+            {
+                prop: "category",
+                name: "Category",
+                type: "multi-select",
+                options: category
+            },
+            {
+                prop: "paint_index",
+                name: "Paint index",
+                type: "multi-select",
+                options: paintIndex
+            },
             {
                 prop: "souvenir",
                 name: "Souvenir",
@@ -75,7 +120,12 @@ async function build(): Promise<BuiltCategory> {
                     { id: "false", name: "No" }
                 ]
             },
-            { prop: "phase", name: "Phase", type: "multi-select", options: phase },
+            {
+                prop: "phase",
+                name: "Phase",
+                type: "multi-select",
+                options: phase
+            },
             {
                 prop: "stattrak",
                 name: "StatTrak™",

--- a/src/services/SkinService.ts
+++ b/src/services/SkinService.ts
@@ -1,20 +1,21 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const skinsRaw = await cachedGet<any[]>(
+    const skinsRaw = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/skins.json`
     )
-    const skins = skinsRaw.reduce((acc: any, item: any) => {
+    const skins = skinsRaw.reduce<Record<string, CSItem>>((acc, item) => {
         acc[item.id] = item
         return acc
     }, {})
 
-    const itemsRaw = await cachedGet<any[]>(
+    const itemsRaw = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/skins_not_grouped.json`
     )
-    const items = itemsRaw.map((item: any) => {
+    const items = itemsRaw.map((item): CSItem => {
         return {
             ...item,
             rare: [

--- a/src/services/SkinService.ts
+++ b/src/services/SkinService.ts
@@ -1,125 +1,70 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
 
-export default class SkinService {
-    async query({
-        search,
-        filters
-    }: {
-        search: string
-        filters: { [prop: string]: string[] }
-    }) {
-        const skinsRaw = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/skins.json`
-        )
-        let skins = skinsRaw.reduce((acc: any, item: any) => {
-            acc[item.id] = item
-            return acc
-        }, {})
+async function build(): Promise<BuiltCategory> {
+    const skinsRaw = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/skins.json`
+    )
+    const skins = skinsRaw.reduce((acc: any, item: any) => {
+        acc[item.id] = item
+        return acc
+    }, {})
 
-        const itemsRaw = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/skins_not_grouped.json`
-        )
-        let items = itemsRaw.map((item: any) => {
-            return {
-                ...item,
-                rare: [
-                    "sfui_invpanel_filter_melee",
-                    "sfui_invpanel_filter_gloves"
-                ].includes(item.category.id),
-                collections: skins[item.skin_id]?.collections ?? [],
-                crates: skins[item.skin_id]?.crates ?? []
-            }
-        })
+    const itemsRaw = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/skins_not_grouped.json`
+    )
+    const items = itemsRaw.map((item: any) => {
+        return {
+            ...item,
+            rare: [
+                "sfui_invpanel_filter_melee",
+                "sfui_invpanel_filter_gloves"
+            ].includes(item.category.id),
+            collections: skins[item.skin_id]?.collections ?? [],
+            crates: skins[item.skin_id]?.crates ?? []
+        }
+    })
 
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
-            {
-                prop: "crates",
-                name: "Crates",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "crates"
-                })
-            },
-            {
-                prop: "collections",
-                name: "Collections",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "collections"
-                })
-            },
-            {
-                prop: "rarity",
-                name: "Rarity",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "rarity"
-                })
-            },
-            {
-                prop: "pattern",
-                name: "Pattern",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "pattern"
-                })
-            },
-            {
-                prop: "style",
-                name: "Finish Style",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "style"
-                })
-            },
-            {
-                prop: "weapon",
-                name: "Weapon",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "weapon"
-                })
-            },
-            {
-                prop: "wear",
-                name: "Wear",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "wear"
-                })
-            },
-            {
-                prop: "category",
-                name: "Category",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "category"
-                })
-            },
-            {
-                prop: "paint_index",
-                name: "Paint index",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "paint_index"
-                })
-            },
+    const [
+        crates,
+        collections,
+        rarity,
+        pattern,
+        style,
+        weapon,
+        wear,
+        category,
+        paintIndex,
+        phase,
+        team
+    ] = generateOptionsBatch(items, [
+        { type: "fromNestedProperty", property: "crates" },
+        { type: "fromNestedProperty", property: "collections" },
+        { type: "fromNestedSingleProperty", property: "rarity" },
+        { type: "fromNestedSingleProperty", property: "pattern" },
+        { type: "fromNestedSingleProperty", property: "style" },
+        { type: "fromNestedSingleProperty", property: "weapon" },
+        { type: "fromNestedSingleProperty", property: "wear" },
+        { type: "fromNestedSingleProperty", property: "category" },
+        { type: "fromProperty", property: "paint_index" },
+        { type: "fromProperty", property: "phase" },
+        { type: "fromNestedSingleProperty", property: "team" }
+    ])
+
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            { prop: "crates", name: "Crates", type: "multi-select", options: crates },
+            { prop: "collections", name: "Collections", type: "multi-select", options: collections },
+            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
+            { prop: "pattern", name: "Pattern", type: "multi-select", options: pattern },
+            { prop: "style", name: "Finish Style", type: "multi-select", options: style },
+            { prop: "weapon", name: "Weapon", type: "multi-select", options: weapon },
+            { prop: "wear", name: "Wear", type: "multi-select", options: wear },
+            { prop: "category", name: "Category", type: "multi-select", options: category },
+            { prop: "paint_index", name: "Paint index", type: "multi-select", options: paintIndex },
             {
                 prop: "souvenir",
                 name: "Souvenir",
@@ -129,15 +74,7 @@ export default class SkinService {
                     { id: "false", name: "No" }
                 ]
             },
-            {
-                prop: "phase",
-                name: "Phase",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "phase"
-                })
-            },
+            { prop: "phase", name: "Phase", type: "multi-select", options: phase },
             {
                 prop: "stattrak",
                 name: "StatTrak™",
@@ -147,15 +84,7 @@ export default class SkinService {
                     { id: "false", name: "No" }
                 ]
             },
-            {
-                prop: "team",
-                name: "Team",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "team"
-                })
-            },
+            { prop: "team", name: "Team", type: "multi-select", options: team },
             {
                 prop: "legacy_model",
                 name: "Legacy model",
@@ -166,16 +95,21 @@ export default class SkinService {
                 ]
             }
         ]
-
-        return {
-            items: filterItems(items, search, filters),
-            filters: filterList
-        }
     }
+}
 
-    async loadSkins(): Promise<any[]> {
-        return cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/skins.json`
-        )
+export default class SkinService {
+    async query({
+        search,
+        filters
+    }: {
+        search: string
+        filters: { [prop: string]: string[] }
+    }) {
+        const built = await getOrBuild("skins", build)
+        return {
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
+        }
     }
 }

--- a/src/services/SouvenirCharmService.ts
+++ b/src/services/SouvenirCharmService.ts
@@ -21,13 +21,43 @@ async function build(): Promise<BuiltCategory> {
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
-            { prop: "tournament_event", name: "Tournament", type: "multi-select", options: tournamentEvent },
-            { prop: "tournament_player", name: "Player", type: "multi-select", options: tournamentPlayer },
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
+            {
+                prop: "tournament_event",
+                name: "Tournament",
+                type: "multi-select",
+                options: tournamentEvent
+            },
+            {
+                prop: "tournament_player",
+                name: "Player",
+                type: "multi-select",
+                options: tournamentPlayer
+            },
             { prop: "map", name: "Map", type: "multi-select", options: map },
-            { prop: "stage", name: "Stage", type: "multi-select", options: stage },
-            { prop: "team0", name: "Team 0", type: "multi-select", options: team0 },
-            { prop: "team1", name: "Team 1", type: "multi-select", options: team1 }
+            {
+                prop: "stage",
+                name: "Stage",
+                type: "multi-select",
+                options: stage
+            },
+            {
+                prop: "team0",
+                name: "Team 0",
+                type: "multi-select",
+                options: team0
+            },
+            {
+                prop: "team1",
+                name: "Team 1",
+                type: "multi-select",
+                options: team1
+            }
         ]
     }
 }

--- a/src/services/SouvenirCharmService.ts
+++ b/src/services/SouvenirCharmService.ts
@@ -1,5 +1,35 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/highlights.json`
+    )
+
+    const [tournamentEvent, tournamentPlayer, map, stage, team0, team1] =
+        generateOptionsBatch(items, [
+            { type: "fromProperty", property: "tournament_event" },
+            { type: "fromProperty", property: "tournament_player" },
+            { type: "fromProperty", property: "map" },
+            { type: "fromProperty", property: "stage" },
+            { type: "fromProperty", property: "team0" },
+            { type: "fromProperty", property: "team1" }
+        ])
+
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            { prop: "tournament_event", name: "Tournament", type: "multi-select", options: tournamentEvent },
+            { prop: "tournament_player", name: "Player", type: "multi-select", options: tournamentPlayer },
+            { prop: "map", name: "Map", type: "multi-select", options: map },
+            { prop: "stage", name: "Stage", type: "multi-select", options: stage },
+            { prop: "team0", name: "Team 0", type: "multi-select", options: team0 },
+            { prop: "team1", name: "Team 1", type: "multi-select", options: team1 }
+        ]
+    }
+}
 
 export default class SouvenirCharmService {
     async query({
@@ -9,76 +39,10 @@ export default class SouvenirCharmService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/highlights.json`
-        )
-
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
-            {
-                prop: "tournament_event",
-                name: "Tournament",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "tournament_event"
-                })
-            },
-            {
-                prop: "tournament_player",
-                name: "Player",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "tournament_player"
-                })
-            },
-            {
-                prop: "map",
-                name: "Map",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "map"
-                })
-            },
-            {
-                prop: "stage",
-                name: "Stage",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "stage"
-                })
-            },
-            {
-                prop: "team0",
-                name: "Team 0",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "team0"
-                })
-            },
-            {
-                prop: "team1",
-                name: "Team 1",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "team1"
-                })
-            }
-        ]
-
+        const built = await getOrBuild("souvenir-charm", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/SouvenirCharmService.ts
+++ b/src/services/SouvenirCharmService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/highlights.json`
     )
 

--- a/src/services/SpecialItemsMatrixService.ts
+++ b/src/services/SpecialItemsMatrixService.ts
@@ -167,6 +167,9 @@ export default class SpecialItemsMatrixService {
             getRowItem: (item: T) => T
             includeCrates?: (item: T) => Crate[] | undefined
             showCountInDisplay?: boolean
+            // Numeric sort key per column; higher values sort to the left.
+            // When omitted, columns fall back to alphabetical order.
+            getColumnSortKey?: (item: T) => number
             customSort?: (
                 a: { key: string; display: string; count: number },
                 b: { key: string; display: string; count: number }
@@ -174,19 +177,31 @@ export default class SpecialItemsMatrixService {
         }
     ): ProcessedMatrixData {
         const columnsSet = new Set<string>()
+        const columnSortKeys = new Map<string, number>()
         const rowMap = new Map<string, T>()
 
         // Collect columns and rows
         for (const item of items) {
             const columnValue = config.getColumnValue(item)
             columnsSet.add(columnValue)
+            if (config.getColumnSortKey && !columnSortKeys.has(columnValue)) {
+                columnSortKeys.set(columnValue, config.getColumnSortKey(item))
+            }
             const rowKey = config.getRowKey(item)
             if (!rowMap.has(rowKey)) {
                 rowMap.set(rowKey, config.getRowItem(item))
             }
         }
 
-        const columns = Array.from(columnsSet).sort()
+        const columns = Array.from(columnsSet).sort((a, b) => {
+            if (config.getColumnSortKey) {
+                const keyA = columnSortKeys.get(a) ?? 0
+                const keyB = columnSortKeys.get(b) ?? 0
+                // Descending: latest (highest key) on the left.
+                if (keyA !== keyB) return keyB - keyA
+            }
+            return String(a).localeCompare(String(b))
+        })
 
         // Pre-compute matrix map
         const map = new Map<string, CellData>()
@@ -267,6 +282,7 @@ export default class SpecialItemsMatrixService {
     ): ProcessedMatrixData {
         return this.processMatrix(filteredItems, {
             getColumnValue: (item) => item.tournament.name,
+            getColumnSortKey: (item) => Number(item.tournament.id),
             getRowKey: (item) => item.team.name,
             getRowDisplay: (item) => item.team.name,
             getRowItem: (item) => item,
@@ -279,6 +295,7 @@ export default class SpecialItemsMatrixService {
     ): ProcessedMatrixData {
         return this.processMatrix(filteredItems, {
             getColumnValue: (item) => item.tournament.name,
+            getColumnSortKey: (item) => Number(item.tournament.id),
             getRowKey: (item) => item.player.name,
             getRowDisplay: (item) => item.player.name,
             getRowItem: (item) => item,

--- a/src/services/SpecialItemsMatrixService.ts
+++ b/src/services/SpecialItemsMatrixService.ts
@@ -77,7 +77,7 @@ export default class SpecialItemsMatrixService {
                 }
             })
             .then((response) => {
-                response.items = response.items.filter((skin: any) => {
+                const knives = response.items.filter((skin) => {
                     if (seensSkins.has(skin.skin_id)) {
                         return false
                     }
@@ -87,7 +87,7 @@ export default class SpecialItemsMatrixService {
                     return true
                 })
 
-                return response.items
+                return knives as unknown as Knife[]
             })
     }
 
@@ -96,9 +96,9 @@ export default class SpecialItemsMatrixService {
             .query({ search: "", filters: {} })
             .then((response) => {
                 return response.items.filter(
-                    (sticker: any) =>
+                    (sticker) =>
                         sticker.tournament && sticker.team && !sticker.player
-                )
+                ) as unknown as TeamSticker[]
             })
     }
 
@@ -107,8 +107,8 @@ export default class SpecialItemsMatrixService {
             .query({ search: "", filters: {} })
             .then((response) => {
                 return response.items.filter(
-                    (sticker: any) => sticker.tournament && sticker.player
-                )
+                    (sticker) => sticker.tournament && sticker.player
+                ) as unknown as PlayerSticker[]
             })
     }
 

--- a/src/services/StickerSlabsService.ts
+++ b/src/services/StickerSlabsService.ts
@@ -1,5 +1,39 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/sticker_slabs.json`
+    )
+
+    const [rarity, crates, collections, type, effect, tournament, team, player] =
+        generateOptionsBatch(items, [
+            { type: "fromNestedSingleProperty", property: "rarity" },
+            { type: "fromNestedProperty", property: "crates" },
+            { type: "fromNestedProperty", property: "collections" },
+            { type: "fromProperty", property: "type" },
+            { type: "fromProperty", property: "effect" },
+            { type: "fromNestedSingleProperty", property: "tournament" },
+            { type: "fromNestedSingleProperty", property: "team" },
+            { type: "fromNestedSingleProperty", property: "player" }
+        ])
+
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
+            { prop: "crates", name: "Crate", type: "multi-select", options: crates },
+            { prop: "collections", name: "Collections", type: "multi-select", options: collections },
+            { prop: "type", name: "Type", type: "multi-select", options: type },
+            { prop: "effect", name: "Effect", type: "multi-select", options: effect },
+            { prop: "tournament", name: "Tournament", type: "multi-select", options: tournament },
+            { prop: "team", name: "Team", type: "multi-select", options: team },
+            { prop: "player", name: "Player", type: "multi-select", options: player }
+        ]
+    }
+}
 
 export default class StickerSlabsService {
     async query({
@@ -9,94 +43,10 @@ export default class StickerSlabsService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/sticker_slabs.json`
-        )
-
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
-            {
-                prop: "rarity",
-                name: "Rarity",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "rarity"
-                })
-            },
-            {
-                prop: "crates",
-                name: "Crate",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "crates"
-                })
-            },
-            {
-                prop: "collections",
-                name: "Collections",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "collections"
-                })
-            },
-            {
-                prop: "type",
-                name: "Type",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "type"
-                })
-            },
-            {
-                prop: "effect",
-                name: "Effect",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "effect"
-                })
-            },
-            {
-                prop: "tournament",
-                name: "Tournament",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "tournament"
-                })
-            },
-            {
-                prop: "team",
-                name: "Team",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "team"
-                })
-            },
-            {
-                prop: "player",
-                name: "Player",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "player"
-                })
-            }
-        ]
-
+        const built = await getOrBuild("sticker-slabs", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/StickerSlabsService.ts
+++ b/src/services/StickerSlabsService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/sticker_slabs.json`
     )
 

--- a/src/services/StickerSlabsService.ts
+++ b/src/services/StickerSlabsService.ts
@@ -8,30 +8,73 @@ async function build(): Promise<BuiltCategory> {
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/sticker_slabs.json`
     )
 
-    const [rarity, crates, collections, type, effect, tournament, team, player] =
-        generateOptionsBatch(items, [
-            { type: "fromNestedSingleProperty", property: "rarity" },
-            { type: "fromNestedProperty", property: "crates" },
-            { type: "fromNestedProperty", property: "collections" },
-            { type: "fromProperty", property: "type" },
-            { type: "fromProperty", property: "effect" },
-            { type: "fromNestedSingleProperty", property: "tournament" },
-            { type: "fromNestedSingleProperty", property: "team" },
-            { type: "fromNestedSingleProperty", property: "player" }
-        ])
+    const [
+        rarity,
+        crates,
+        collections,
+        type,
+        effect,
+        tournament,
+        team,
+        player
+    ] = generateOptionsBatch(items, [
+        { type: "fromNestedSingleProperty", property: "rarity" },
+        { type: "fromNestedProperty", property: "crates" },
+        { type: "fromNestedProperty", property: "collections" },
+        { type: "fromProperty", property: "type" },
+        { type: "fromProperty", property: "effect" },
+        { type: "fromNestedSingleProperty", property: "tournament" },
+        { type: "fromNestedSingleProperty", property: "team" },
+        { type: "fromNestedSingleProperty", property: "player" }
+    ])
 
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
-            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
-            { prop: "crates", name: "Crate", type: "multi-select", options: crates },
-            { prop: "collections", name: "Collections", type: "multi-select", options: collections },
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
+            {
+                prop: "rarity",
+                name: "Rarity",
+                type: "multi-select",
+                options: rarity
+            },
+            {
+                prop: "crates",
+                name: "Crate",
+                type: "multi-select",
+                options: crates
+            },
+            {
+                prop: "collections",
+                name: "Collections",
+                type: "multi-select",
+                options: collections
+            },
             { prop: "type", name: "Type", type: "multi-select", options: type },
-            { prop: "effect", name: "Effect", type: "multi-select", options: effect },
-            { prop: "tournament", name: "Tournament", type: "multi-select", options: tournament },
+            {
+                prop: "effect",
+                name: "Effect",
+                type: "multi-select",
+                options: effect
+            },
+            {
+                prop: "tournament",
+                name: "Tournament",
+                type: "multi-select",
+                options: tournament
+            },
             { prop: "team", name: "Team", type: "multi-select", options: team },
-            { prop: "player", name: "Player", type: "multi-select", options: player }
+            {
+                prop: "player",
+                name: "Player",
+                type: "multi-select",
+                options: player
+            }
         ]
     }
 }

--- a/src/services/StickersService.ts
+++ b/src/services/StickersService.ts
@@ -1,5 +1,39 @@
 import { cachedGet } from "../utils/apiCache"
-import { filterItems, generateOptions } from "../utils"
+import { filterItems, generateOptionsBatch } from "../utils"
+import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+
+async function build(): Promise<BuiltCategory> {
+    const items = await cachedGet<any[]>(
+        `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/stickers.json`
+    )
+
+    const [rarity, crates, collections, type, effect, tournament, team, player] =
+        generateOptionsBatch(items, [
+            { type: "fromNestedSingleProperty", property: "rarity" },
+            { type: "fromNestedProperty", property: "crates" },
+            { type: "fromNestedProperty", property: "collections" },
+            { type: "fromProperty", property: "type" },
+            { type: "fromProperty", property: "effect" },
+            { type: "fromNestedSingleProperty", property: "tournament" },
+            { type: "fromNestedSingleProperty", property: "team" },
+            { type: "fromNestedSingleProperty", property: "player" }
+        ])
+
+    return {
+        items,
+        filters: [
+            { prop: "price_range", name: "Price", type: "price-range", options: [] },
+            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
+            { prop: "crates", name: "Crate", type: "multi-select", options: crates },
+            { prop: "collections", name: "Collections", type: "multi-select", options: collections },
+            { prop: "type", name: "Type", type: "multi-select", options: type },
+            { prop: "effect", name: "Effect", type: "multi-select", options: effect },
+            { prop: "tournament", name: "Tournament", type: "multi-select", options: tournament },
+            { prop: "team", name: "Team", type: "multi-select", options: team },
+            { prop: "player", name: "Player", type: "multi-select", options: player }
+        ]
+    }
+}
 
 export default class StickersService {
     async query({
@@ -9,94 +43,10 @@ export default class StickersService {
         search: string
         filters: { [prop: string]: string[] }
     }) {
-        let items = await cachedGet<any[]>(
-            `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/stickers.json`
-        )
-
-        const filterList = [
-            {
-                prop: "price_range",
-                name: "Price",
-                type: "price-range",
-                options: []
-            },
-            {
-                prop: "rarity",
-                name: "Rarity",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "rarity"
-                })
-            },
-            {
-                prop: "crates",
-                name: "Crate",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "crates"
-                })
-            },
-            {
-                prop: "collections",
-                name: "Collections",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedProperty",
-                    property: "collections"
-                })
-            },
-            {
-                prop: "type",
-                name: "Type",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "type"
-                })
-            },
-            {
-                prop: "effect",
-                name: "Effect",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromProperty",
-                    property: "effect"
-                })
-            },
-            {
-                prop: "tournament",
-                name: "Tournament",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "tournament"
-                })
-            },
-            {
-                prop: "team",
-                name: "Team",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "team"
-                })
-            },
-            {
-                prop: "player",
-                name: "Player",
-                type: "multi-select",
-                options: generateOptions(items, {
-                    type: "fromNestedSingleProperty",
-                    property: "player"
-                })
-            }
-        ]
-
+        const built = await getOrBuild("stickers", build)
         return {
-            items: filterItems(items, search, filters),
-            filters: filterList
+            items: filterItems(built.items, search, filters),
+            filters: built.filters
         }
     }
 }

--- a/src/services/StickersService.ts
+++ b/src/services/StickersService.ts
@@ -1,9 +1,10 @@
 import { cachedGet } from "../utils/apiCache"
 import { filterItems, generateOptionsBatch } from "../utils"
 import { getOrBuild, BuiltCategory } from "../utils/processedCache"
+import { CSItem } from "../types"
 
 async function build(): Promise<BuiltCategory> {
-    const items = await cachedGet<any[]>(
+    const items = await cachedGet<CSItem[]>(
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/stickers.json`
     )
 

--- a/src/services/StickersService.ts
+++ b/src/services/StickersService.ts
@@ -8,30 +8,73 @@ async function build(): Promise<BuiltCategory> {
         `https://raw.githubusercontent.com/ByMykel/CSGO-API/main/public/api/en/stickers.json`
     )
 
-    const [rarity, crates, collections, type, effect, tournament, team, player] =
-        generateOptionsBatch(items, [
-            { type: "fromNestedSingleProperty", property: "rarity" },
-            { type: "fromNestedProperty", property: "crates" },
-            { type: "fromNestedProperty", property: "collections" },
-            { type: "fromProperty", property: "type" },
-            { type: "fromProperty", property: "effect" },
-            { type: "fromNestedSingleProperty", property: "tournament" },
-            { type: "fromNestedSingleProperty", property: "team" },
-            { type: "fromNestedSingleProperty", property: "player" }
-        ])
+    const [
+        rarity,
+        crates,
+        collections,
+        type,
+        effect,
+        tournament,
+        team,
+        player
+    ] = generateOptionsBatch(items, [
+        { type: "fromNestedSingleProperty", property: "rarity" },
+        { type: "fromNestedProperty", property: "crates" },
+        { type: "fromNestedProperty", property: "collections" },
+        { type: "fromProperty", property: "type" },
+        { type: "fromProperty", property: "effect" },
+        { type: "fromNestedSingleProperty", property: "tournament" },
+        { type: "fromNestedSingleProperty", property: "team" },
+        { type: "fromNestedSingleProperty", property: "player" }
+    ])
 
     return {
         items,
         filters: [
-            { prop: "price_range", name: "Price", type: "price-range", options: [] },
-            { prop: "rarity", name: "Rarity", type: "multi-select", options: rarity },
-            { prop: "crates", name: "Crate", type: "multi-select", options: crates },
-            { prop: "collections", name: "Collections", type: "multi-select", options: collections },
+            {
+                prop: "price_range",
+                name: "Price",
+                type: "price-range",
+                options: []
+            },
+            {
+                prop: "rarity",
+                name: "Rarity",
+                type: "multi-select",
+                options: rarity
+            },
+            {
+                prop: "crates",
+                name: "Crate",
+                type: "multi-select",
+                options: crates
+            },
+            {
+                prop: "collections",
+                name: "Collections",
+                type: "multi-select",
+                options: collections
+            },
             { prop: "type", name: "Type", type: "multi-select", options: type },
-            { prop: "effect", name: "Effect", type: "multi-select", options: effect },
-            { prop: "tournament", name: "Tournament", type: "multi-select", options: tournament },
+            {
+                prop: "effect",
+                name: "Effect",
+                type: "multi-select",
+                options: effect
+            },
+            {
+                prop: "tournament",
+                name: "Tournament",
+                type: "multi-select",
+                options: tournament
+            },
             { prop: "team", name: "Team", type: "multi-select", options: team },
-            { prop: "player", name: "Player", type: "multi-select", options: player }
+            {
+                prop: "player",
+                name: "Player",
+                type: "multi-select",
+                options: player
+            }
         ]
     }
 }

--- a/src/stores/list.ts
+++ b/src/stores/list.ts
@@ -230,7 +230,10 @@ export const createListStore =
                 // part of the public type, so narrow it explicitly.
                 const pinia = getActivePinia() as
                     | (Pinia & {
-                          _s?: Map<string, { $id: string; $dispose: () => void }>
+                          _s?: Map<
+                              string,
+                              { $id: string; $dispose: () => void }
+                          >
                       })
                     | undefined
                 pinia?._s?.forEach((store) => {

--- a/src/stores/list.ts
+++ b/src/stores/list.ts
@@ -209,6 +209,7 @@ export const createListStore =
                         key !== "q" &&
                         key !== "itemId" &&
                         key !== "sort" &&
+                        key !== "video" &&
                         value
                     ) {
                         if (typeof value === "string") {

--- a/src/stores/list.ts
+++ b/src/stores/list.ts
@@ -29,9 +29,9 @@ export const createListStore =
             const loading = ref<boolean>(false)
             const search = ref<string>("")
             const sortBy = ref<string>("")
-            const page = ref<number>(1)
             const rawItems = ref<any[]>([])
-            const allItems = ref<any[]>([])
+            // Full filtered + sorted list. The view virtualizes it, so there
+            // is no pagination — every matching item is exposed at once.
             const items = ref<any[]>([])
             const itemsCount = ref<number>(0)
             const filters = ref<Filter[]>([])
@@ -42,7 +42,7 @@ export const createListStore =
 
                 const direction = sortBy.value === "price-asc" ? 1 : -1
 
-                allItems.value.sort((a, b) => {
+                items.value.sort((a, b) => {
                     const priceA = priceStore.prices[a.market_hash_name] ?? null
                     const priceB = priceStore.prices[b.market_hash_name] ?? null
 
@@ -54,16 +54,11 @@ export const createListStore =
                 })
             }
 
-            function reslice() {
-                page.value = 1
-                items.value = allItems.value.slice(0, 20)
-            }
-
             function applyPriceFilter() {
                 const priceRange = filtersValues.value.price_range
                 if (priceRange?.length === 2) {
                     const [minCents, maxCents] = priceRange.map(Number)
-                    allItems.value = rawItems.value.filter((item) => {
+                    items.value = rawItems.value.filter((item) => {
                         const price = priceStore.prices[item.market_hash_name]
                         if (price == null) return false
                         if (minCents && price < minCents) return false
@@ -71,17 +66,15 @@ export const createListStore =
                         return true
                     })
                 } else {
-                    allItems.value = [...rawItems.value]
+                    items.value = [...rawItems.value]
                 }
                 sortItems()
-                itemsCount.value = allItems.value.length
-                reslice()
+                itemsCount.value = items.value.length
             }
 
             async function fetch() {
                 loading.value = true
                 reset()
-                page.value = 1
                 try {
                     const { price_range, ...serviceFilters } =
                         filtersValues.value
@@ -91,11 +84,10 @@ export const createListStore =
                             filters: serviceFilters
                         })
                     rawItems.value = newItems
-                    allItems.value = [...newItems]
 
                     if (price_range?.length === 2) {
                         const [minCents, maxCents] = price_range.map(Number)
-                        allItems.value = allItems.value.filter((item) => {
+                        items.value = newItems.filter((item) => {
                             const price =
                                 priceStore.prices[item.market_hash_name]
                             if (price == null) return false
@@ -103,14 +95,12 @@ export const createListStore =
                             if (maxCents && price > maxCents) return false
                             return true
                         })
+                    } else {
+                        items.value = [...newItems]
                     }
 
                     sortItems()
-                    itemsCount.value = allItems.value.length
-                    items.value = allItems.value.slice(
-                        (page.value - 1) * 20,
-                        page.value * 20
-                    )
+                    itemsCount.value = items.value.length
                     filters.value = newFilters ?? []
                 } catch (error) {
                     console.error(
@@ -121,16 +111,6 @@ export const createListStore =
                 } finally {
                     loading.value = false
                 }
-            }
-
-            async function loadMore() {
-                page.value += 1
-                items.value.push(
-                    ...allItems.value.slice(
-                        (page.value - 1) * 20,
-                        page.value * 20
-                    )
-                )
             }
 
             function setSearch(newSearch: string) {
@@ -161,14 +141,14 @@ export const createListStore =
 
             function setSortBy(value: string) {
                 sortBy.value = value
+                // Re-sort in place, then reassign to trigger reactivity.
                 sortItems()
-                reslice()
+                items.value = [...items.value]
                 saveSearchQueryParam()
             }
 
             function reset() {
                 items.value = []
-                allItems.value = []
                 rawItems.value = []
                 itemsCount.value = 0
             }
@@ -265,7 +245,6 @@ export const createListStore =
 
                 fetch,
                 applyPriceFilter,
-                loadMore,
                 setSearch,
                 setSortBy,
                 setFilters,

--- a/src/stores/list.ts
+++ b/src/stores/list.ts
@@ -1,7 +1,7 @@
 import { onUnmounted, onMounted, ref } from "vue"
-import { defineStore, getActivePinia } from "pinia"
+import { defineStore, getActivePinia, type Pinia } from "pinia"
 import { useRoute, useRouter } from "vue-router"
-import { Filter } from "../types"
+import { CSItem, Filter } from "../types"
 import { usePriceStore } from "./prices"
 
 type QueryFunction = ({
@@ -13,7 +13,7 @@ type QueryFunction = ({
     search: string
     filters: { [prop: string]: string[] }
 }) => Promise<{
-    items: any[]
+    items: CSItem[]
     filters?: Filter[]
 }>
 
@@ -29,10 +29,10 @@ export const createListStore =
             const loading = ref<boolean>(false)
             const search = ref<string>("")
             const sortBy = ref<string>("")
-            const rawItems = ref<any[]>([])
+            const rawItems = ref<CSItem[]>([])
             // Full filtered + sorted list. The view virtualizes it, so there
             // is no pagination — every matching item is exposed at once.
-            const items = ref<any[]>([])
+            const items = ref<CSItem[]>([])
             const itemsCount = ref<number>(0)
             const filters = ref<Filter[]>([])
             const filtersValues = ref<{ [prop: string]: string[] }>({})
@@ -43,8 +43,10 @@ export const createListStore =
                 const direction = sortBy.value === "price-asc" ? 1 : -1
 
                 items.value.sort((a, b) => {
-                    const priceA = priceStore.prices[a.market_hash_name] ?? null
-                    const priceB = priceStore.prices[b.market_hash_name] ?? null
+                    const priceA =
+                        priceStore.prices[a.market_hash_name ?? ""] ?? null
+                    const priceB =
+                        priceStore.prices[b.market_hash_name ?? ""] ?? null
 
                     if (priceA === null && priceB === null) return 0
                     if (priceA === null) return 1
@@ -59,7 +61,8 @@ export const createListStore =
                 if (priceRange?.length === 2) {
                     const [minCents, maxCents] = priceRange.map(Number)
                     items.value = rawItems.value.filter((item) => {
-                        const price = priceStore.prices[item.market_hash_name]
+                        const price =
+                            priceStore.prices[item.market_hash_name ?? ""]
                         if (price == null) return false
                         if (minCents && price < minCents) return false
                         if (maxCents && price > maxCents) return false
@@ -89,7 +92,7 @@ export const createListStore =
                         const [minCents, maxCents] = price_range.map(Number)
                         items.value = newItems.filter((item) => {
                             const price =
-                                priceStore.prices[item.market_hash_name]
+                                priceStore.prices[item.market_hash_name ?? ""]
                             if (price == null) return false
                             if (minCents && price < minCents) return false
                             if (maxCents && price > maxCents) return false
@@ -222,9 +225,14 @@ export const createListStore =
             })
 
             onUnmounted(() => {
-                // TODO: find solution to ` Property '_s' does not exist on type 'Pinia'.ts(2339) `
-                // @ts-ignore
-                getActivePinia()?._s?.forEach((store: any) => {
+                // `_s` is Pinia's internal registry of active stores; it isn't
+                // part of the public type, so narrow it explicitly.
+                const pinia = getActivePinia() as
+                    | (Pinia & {
+                          _s?: Map<string, { $id: string; $dispose: () => void }>
+                      })
+                    | undefined
+                pinia?._s?.forEach((store) => {
                     if (store.$id === `list/${id}`) {
                         store.$dispose()
                         setSearch("")

--- a/src/style.css
+++ b/src/style.css
@@ -9,6 +9,29 @@
 }
 
 @layer utilities {
+    /* Thin, subtle scrollbar for the sidebar nav */
+    .sidebar-scroll {
+        scrollbar-width: thin;
+        scrollbar-color: #2c2c2c transparent;
+    }
+
+    .sidebar-scroll::-webkit-scrollbar {
+        width: 4px;
+    }
+
+    .sidebar-scroll::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    .sidebar-scroll::-webkit-scrollbar-thumb {
+        background: #2c2c2c;
+        border-radius: 9999px;
+    }
+
+    .sidebar-scroll:hover::-webkit-scrollbar-thumb {
+        background: #3a3a3a;
+    }
+
     .no-scrollbar::-webkit-scrollbar {
         display: none;
     }

--- a/src/style.css
+++ b/src/style.css
@@ -63,12 +63,12 @@
     }
 
     .items-grid {
-        grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-        grid-template-rows: repeat(auto-fill, minmax(200px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+        grid-template-rows: repeat(auto-fill, minmax(216px, 1fr));
     }
 
     .items-grid-small {
-        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-        grid-template-rows: repeat(auto-fill, minmax(170px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(155px, 1fr));
+        grid-template-rows: repeat(auto-fill, minmax(190px, 1fr));
     }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,11 +39,40 @@ interface specialNotes {
     source: string
 }
 
+export type FilterOption = {
+    id: string | null
+    name: string
+}
+
 export type Filter = {
     prop: string
     name: string
     type: string
-    options: { id: string; name: string }[]
+    options: FilterOption[]
+}
+
+/**
+ * A CS item from the CSGO-API. The API returns many different item shapes
+ * (skins, stickers, agents, crates, …) and the app filters them generically
+ * by arbitrary property names, so only the fields consumed directly by the UI
+ * are typed; the index signature covers the rest.
+ */
+export interface CSItem {
+    id: string
+    name: string
+    description?: string
+    image?: string
+    market_hash_name?: string
+    rarity?: { id: string; name: string; color?: string } | null
+    souvenir?: boolean
+    stattrak?: boolean
+    genuine?: boolean
+    phase?: string | null
+    // Highlight / video items
+    video?: string
+    thumbnail?: string
+    // Category-specific properties read by the generic filter/option code.
+    [key: string]: any
 }
 
 interface Rarity {

--- a/src/utils/apiCache.ts
+++ b/src/utils/apiCache.ts
@@ -8,16 +8,20 @@ interface CacheEntry {
 const cache = new Map<string, CacheEntry>()
 const TTL = 5 * 60 * 1000 // 5 minutes
 
+// Returns the cached reference directly (no structuredClone). Callers must
+// treat the result as immutable / read-only. The one consumer that needs to
+// mutate its result (HomeService.getAllItems) copies defensively before doing
+// so. Cloning multi-MB payloads on every call was a major source of jank.
 export async function cachedGet<T = unknown>(url: string): Promise<T> {
     const entry = cache.get(url)
 
     if (entry && Date.now() - entry.timestamp < TTL) {
-        return structuredClone(entry.data) as T
+        return entry.data as T
     }
 
     const data = await axios.get(url).then((res) => res.data)
 
     cache.set(url, { data, timestamp: Date.now() })
 
-    return structuredClone(data) as T
+    return data as T
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -210,3 +210,73 @@ export function generateOptions(
     // @ts-ignore
     return uniqBy(options.filter(Boolean), "id")
 }
+
+type OptionConfig = {
+    type:
+        | "fromProperty"
+        | "fromNestedProperty"
+        | "fromNestedSingleProperty"
+    property: string
+}
+
+/**
+ * Like `generateOptions`, but computes several filter option-sets in a single
+ * pass over `items` (instead of one full pass per filter). Returns the option
+ * arrays in the same order as `configs`.
+ */
+export function generateOptionsBatch(
+    items: any[],
+    configs: OptionConfig[]
+): { id: string; name: string }[][] {
+    const seen = configs.map(() => new Set<string>())
+    const out: { id: string; name: string }[][] = configs.map(() => [])
+
+    for (const item of items) {
+        for (let i = 0; i < configs.length; i++) {
+            const { type, property } = configs[i]
+            const value = item[property]
+
+            switch (type) {
+                case "fromProperty": {
+                    if (!value) break
+                    const id = String(value)
+                    if (!seen[i].has(id)) {
+                        seen[i].add(id)
+                        out[i].push({ id, name: id })
+                    }
+                    break
+                }
+                case "fromNestedSingleProperty": {
+                    if (!value) break
+                    if (String(value.id) === "null") {
+                        if (!seen[i].has("null")) {
+                            seen[i].add("null")
+                            // Matches generateOptions: id null, name "None"
+                            out[i].push({ id: null as any, name: "None" })
+                        }
+                        break
+                    }
+                    const id = String(value.id)
+                    if (!seen[i].has(id)) {
+                        seen[i].add(id)
+                        out[i].push({ id, name: String(value.name) })
+                    }
+                    break
+                }
+                case "fromNestedProperty": {
+                    if (!value) break
+                    for (const v of value) {
+                        const id = String(v.id)
+                        if (!seen[i].has(id)) {
+                            seen[i].add(id)
+                            out[i].push({ id, name: String(v.name) })
+                        }
+                    }
+                    break
+                }
+            }
+        }
+    }
+
+    return out
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,9 +1,9 @@
 import Fuse from "fuse.js"
-import uniqBy from "lodash.uniqby"
+import { CSItem, FilterOption } from "../types"
 
-const fuseCache = new Map<string, Fuse<any>>()
+const fuseCache = new Map<string, Fuse<CSItem>>()
 
-function getFuseIndex(items: any[], keys: string[]): Fuse<any> {
+function getFuseIndex(items: CSItem[], keys: string[]): Fuse<CSItem> {
     const first = items[0]?.id ?? ""
     const last = items[items.length - 1]?.id ?? ""
     const cacheKey = `${items.length}:${first}:${last}`
@@ -26,7 +26,7 @@ function getFuseIndex(items: any[], keys: string[]): Fuse<any> {
     return fuse
 }
 
-function exactTokenMatch(item: any, tokens: string[]): boolean {
+function exactTokenMatch(item: CSItem, tokens: string[]): boolean {
     const name = (item.name ?? "").toLowerCase()
     const marketName = (item.market_hash_name ?? "").toLowerCase()
     return tokens.every(
@@ -47,7 +47,7 @@ function hashString(str: string) {
     return hash
 }
 
-export function shuffleArrayWithSeed(array: any[], str = "") {
+export function shuffleArrayWithSeed<T>(array: T[], str = ""): T[] {
     let seed = hashString(str)
     const seededRandom = (max: number) => {
         const x = Math.sin(seed++) * 10000
@@ -80,10 +80,10 @@ export function shuffleArrayWithSeed(array: any[], str = "") {
  * @returns {Array} The filtered array of items.
  */
 export function filterItems(
-    items: any[],
+    items: CSItem[],
     search = "",
     filters: { [prop: string]: string[] } = {}
-) {
+): CSItem[] {
     const searchProperties = ["name", "market_hash_name"]
 
     let filteredItems = items
@@ -139,78 +139,6 @@ export function filterItems(
     return filteredItems
 }
 
-/**
- * Generates unique options for filtering from an array of items based on a configuration.
- *
- * @param {Array} items - The array of items from which to generate filter options.
- * @param {Object} config - Configuration object specifying how to extract and process options.
- *    - type: Specifies the method of extraction. Can be one of "fromProperty", "fromNestedProperty", or "fromNestedSingleProperty".
- *    - property: The name of the property from items to base the options on.
- *
- * Examples of config:
- *
- * - For a simple property on each item (e.g., "type" where each item has a type property that's a string):
- *   { type: "fromProperty", property: "type" }
- *
- * - For a nested property array on each item (e.g., "crates" where each item may have an array of crate objects, each with its own id and name):
- *   { type: "fromNestedProperty", property: "crates" }
- *
- * - For a nested single property on each item (e.g., "rarity" where each item has a rarity object with its own id and name):
- *   { type: "fromNestedSingleProperty", property: "rarity" }
- *
- * @returns {Array} A unique array of options based on the provided configuration.
- */
-export function generateOptions(
-    items: any,
-    config: any
-): { id: string; name: string }[] {
-    let options = []
-
-    switch (config.type) {
-        case "fromProperty":
-            // Directly maps each item's specified property to an option, assuming the property is a simple value.
-            options = items
-                .filter((item: any) => item[config.property])
-                .map((item: any) => {
-                    const value = item[config.property]
-                    return { id: String(value), name: String(value) }
-                })
-            break
-        case "fromNestedProperty":
-            // Maps and flattens items' specified nested array property to options, assuming each object in the array has id and name.
-            options = items.flatMap((item: any) => {
-                const value = item[config.property]
-                return value
-                    ? value.map((v: any) => ({
-                          id: String(v.id),
-                          name: String(v.name)
-                      }))
-                    : []
-            })
-            break
-        case "fromNestedSingleProperty":
-            // Maps each item's specified nested property to an option, assuming the nested object has id and name.
-            options = items
-                .filter((item: any) => item[config.property])
-                .map((item: any) => {
-                    const value = item[config.property]
-                    if (String(value.id) === "null") {
-                        return { id: null, name: "None" }
-                    }
-                    return { id: String(value.id), name: String(value.name) }
-                })
-            break
-        default:
-            console.error("Invalid config type")
-            return []
-    }
-
-    // Removing duplicates for all cases based on the id to ensure uniqueness
-    // TODO: avoid using ts-ignore
-    // @ts-ignore
-    return uniqBy(options.filter(Boolean), "id")
-}
-
 type OptionConfig = {
     type:
         | "fromProperty"
@@ -225,11 +153,11 @@ type OptionConfig = {
  * arrays in the same order as `configs`.
  */
 export function generateOptionsBatch(
-    items: any[],
+    items: CSItem[],
     configs: OptionConfig[]
-): { id: string; name: string }[][] {
+): FilterOption[][] {
     const seen = configs.map(() => new Set<string>())
-    const out: { id: string; name: string }[][] = configs.map(() => [])
+    const out: FilterOption[][] = configs.map(() => [])
 
     for (const item of items) {
         for (let i = 0; i < configs.length; i++) {
@@ -251,8 +179,8 @@ export function generateOptionsBatch(
                     if (String(value.id) === "null") {
                         if (!seen[i].has("null")) {
                             seen[i].add("null")
-                            // Matches generateOptions: id null, name "None"
-                            out[i].push({ id: null as any, name: "None" })
+                            // Nested prop explicitly "null" → a "None" option.
+                            out[i].push({ id: null, name: "None" })
                         }
                         break
                     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -140,10 +140,7 @@ export function filterItems(
 }
 
 type OptionConfig = {
-    type:
-        | "fromProperty"
-        | "fromNestedProperty"
-        | "fromNestedSingleProperty"
+    type: "fromProperty" | "fromNestedProperty" | "fromNestedSingleProperty"
     property: string
 }
 

--- a/src/utils/processedCache.ts
+++ b/src/utils/processedCache.ts
@@ -1,7 +1,7 @@
-import { Filter } from "../types"
+import { CSItem, Filter } from "../types"
 
 export interface BuiltCategory {
-    items: any[]
+    items: CSItem[]
     filters: Filter[]
 }
 

--- a/src/utils/processedCache.ts
+++ b/src/utils/processedCache.ts
@@ -1,0 +1,43 @@
+import { Filter } from "../types"
+
+export interface BuiltCategory {
+    items: any[]
+    filters: Filter[]
+}
+
+// Session-lived, in-memory cache of the expensive per-category build
+// (fetch + enhance + filter-option generation). Survives in-app navigation
+// so switching pages never reprocesses. Cross-reload persistence is handled
+// by the service worker caching the raw JSON responses.
+const cache = new Map<string, BuiltCategory>()
+const inflight = new Map<string, Promise<BuiltCategory>>()
+
+export async function getOrBuild(
+    key: string,
+    builder: () => Promise<BuiltCategory>
+): Promise<BuiltCategory> {
+    const cached = cache.get(key)
+    if (cached) return cached
+
+    const existing = inflight.get(key)
+    if (existing) return existing
+
+    const promise = builder()
+        .then((built) => {
+            cache.set(key, built)
+            inflight.delete(key)
+            return built
+        })
+        .catch((error) => {
+            inflight.delete(key)
+            throw error
+        })
+
+    inflight.set(key, promise)
+    return promise
+}
+
+export function clearProcessedCache(key?: string) {
+    if (key) cache.delete(key)
+    else cache.clear()
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
                     {
                         urlPattern:
                             /^https:\/\/raw\.githubusercontent\.com\/ByMykel\/CSGO-API\/.*/i,
-                        handler: "NetworkFirst",
+                        handler: "StaleWhileRevalidate",
                         options: {
                             cacheName: "csgo-api-data",
                             expiration: {


### PR DESCRIPTION
## Performance
- **Processed in-memory cache** per category — fixes the ~1s freeze on every page switch (was refetching + re-cloning + reprocessing on each nav/search); services split into a memoized `build()` + thin `query()`; dropped `structuredClone`; service worker `StaleWhileRevalidate`.
- **Virtualized item grid** (`@vueuse/core`) with pagination removed — DOM stays constant regardless of list size.

## Features / UX
- **Matrix**: tournament columns sorted chronologically (latest → left).
- **Highlights**: click opens a centered **video modal** — prev/next (+ arrow keys), autoplay-next, Steam Community Market link, aspect-ratio-correct, mobile-friendly, and a shareable `?video=<id>` URL.
- **Item detail**: specifications table (Finish Style, Paint index, Pattern ID, Phase, Legacy model, Def index).
- **Debug**: raw item data rendered as readable tables (links, one-line values, horizontal scroll).
- **Sidebar**: icons + brand-accent active state, thin scrollbar, group dividers.
- Larger item cards; image loading spinners on cards and matrix cells.

## Chore
- Introduce a shared `CSItem` type; remove `any`/`ts-ignore` at the seams (71 → 14 `any`, 0 `ts-ignore`/`as any`).
- Add missing eslint flat-config deps (`globals`, `@eslint/js`, `@eslint/eslintrc`) so lint runs.
- Prettier formatting; `npm audit fix` (0 vulnerabilities).

**Verified:** type-check ✅ · lint ✅ · build ✅ · audit ✅